### PR TITLE
[DevOps-87]: Migrate Helm Charts to Repo

### DIFF
--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -1,9 +1,8 @@
 name: Publish Helm chart test
 
 on:
-  push:
-    branches:
-      - "DEVOPS-87-move-helm-charts-to-their-on-repo"
+  pull_request:
+    branches: [main]
 
 jobs:
   release:

--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -2,34 +2,32 @@ name: Publish Helm chart
 
 on:
   push:
-    branches: [main]
+    branches: [DEVOPS-87-move-helm-charts-to-their-on-repo]
     paths:
       - "charts/**"
 
 jobs:
-  build:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout helm-charts
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
-          repository: Topl/helm-charts
-          ref: refs/heads/gh-pages
-          path: helm-charts
-          token: ${{ secrets.CHART_PUBLISH_TOKEN }}
+          fetch-depth: 0
 
-      - name: Publish the Helm chart
-        id: publish-chart
-        uses: moikot/chart-publish-action@v1
-        with:
-          charts_dir: "helm-charts"
-          charts_url: "https://topl.github.io/helm-charts"
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Commit and push helm-charts
-        uses: EndBug/add-and-commit@v6
-        with:
-          author_name: Toplprotocol
-          author_email: info@topl.me
-          branch: gh-pages
-          cwd: helm-charts
-          message: "Commit chart ${{ steps.publish-chart.outputs.chart }}"
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -3,8 +3,8 @@ name: Publish Helm chart
 on:
   push:
     branches: [DEVOPS-87-move-helm-charts-to-their-on-repo]
-    paths:
-      - "charts/**"
+    # paths:
+    #   - "charts/**"
 
 jobs:
   release:

--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -1,0 +1,35 @@
+name: Publish Helm chart
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "charts/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout helm-charts
+        uses: actions/checkout@v2
+        with:
+          repository: Topl/helm-charts
+          ref: refs/heads/gh-pages
+          path: helm-charts
+          token: ${{ secrets.CHART_PUBLISH_TOKEN }}
+
+      - name: Publish the Helm chart
+        id: publish-chart
+        uses: moikot/chart-publish-action@v1
+        with:
+          charts_dir: "helm-charts"
+          charts_url: "https://topl.github.io/helm-charts"
+
+      - name: Commit and push helm-charts
+        uses: EndBug/add-and-commit@v6
+        with:
+          author_name: Toplprotocol
+          author_email: info@topl.me
+          branch: gh-pages
+          cwd: helm-charts
+          message: "Commit chart ${{ steps.publish-chart.outputs.chart }}"

--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish Helm chart
+name: Publish Helm chart test
 
 on:
   push:

--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -2,9 +2,8 @@ name: Publish Helm chart test
 
 on:
   push:
-    branches: ["DEVOPS-87-move-helm-charts-to-their-on-repo"]
-    # paths:
-    #   - "charts/**"
+    branches:
+      - "DEVOPS-87-move-helm-charts-to-their-on-repo"
 
 jobs:
   release:

--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -2,8 +2,8 @@ name: Publish Helm chart test
 
 on:
   push:
-    branches:
-      - "DEVOPS-87-move-helm-charts-to-their-on-repo"
+    # branches:
+    #   - "DEVOPS-87-move-helm-charts-to-their-on-repo"
 
 jobs:
   release:

--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -2,8 +2,8 @@ name: Publish Helm chart test
 
 on:
   push:
-    # branches:
-    #   - "DEVOPS-87-move-helm-charts-to-their-on-repo"
+    branches:
+      - "DEVOPS-87-move-helm-charts-to-their-on-repo"
 
 jobs:
   release:

--- a/.github/configs/workflows/publish.yaml
+++ b/.github/configs/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish Helm chart test
 
 on:
   push:
-    branches: [DEVOPS-87-move-helm-charts-to-their-on-repo]
+    branches: ["DEVOPS-87-move-helm-charts-to-their-on-repo"]
     # paths:
     #   - "charts/**"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,8 @@
 name: Publish Helm chart test
 
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches: [DEVOPS-87-move-helm-charts-to-their-on-repo]
 
 jobs:
   release:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,8 @@
-name: Publish Helm chart test
+name: Chart Publish
 
 on:
   push:
-    branches: [DEVOPS-87-move-helm-charts-to-their-on-repo]
+    branches: [main]
 
 jobs:
   release:

--- a/charts/.checkov.yaml
+++ b/charts/.checkov.yaml
@@ -1,0 +1,12 @@
+skip-check:
+  - CKV_K8S_8 # Ignore until we support liveliness probes
+  - CKV_K8S_9 # Ignore until we support readiness probes
+  - CKV_K8S_14 # Ignore since default should just pull latest tag, users will override specific version: https://docs.bridgecrew.io/docs/bc_k8s_13.
+  - CKV_K8S_38 # Simulation Orchestrator Pod requires service account
+  - CKV_K8S_43 # Ignore since users will override the default Docker image: https://docs.bridgecrew.io/docs/bc_k8s_39.
+  - CKV_K8S_21 # Ignore since users will override the namespace when deploying with Helm: https://docs.bridgecrew.io/docs/bc_k8s_20.
+  - CKV_K8S_40 # TODO: Remove this once the Bifrost Docker image is using a high UID.
+evaluate-variables: true
+framework: all
+output: cli
+quiet: true

--- a/charts/bifrost-consensus-testnet/.helmignore
+++ b/charts/bifrost-consensus-testnet/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/bifrost-consensus-testnet/Chart.yaml
+++ b/charts/bifrost-consensus-testnet/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: bifrost-consensus-testnet
+description: Launches a private testnet using configurable nodes and artificial throttling.
+
+type: application
+
+version: 0.1.0
+
+appVersion: "2.0.0-alpha1"
+
+#TODO: Find a better icon.
+icon: https://uploads-ssl.webflow.com/60f98f46d44e675abb7e66ea/611c4d83ed3df101fd221875_topl_basew.svg

--- a/charts/bifrost-consensus-testnet/README.md
+++ b/charts/bifrost-consensus-testnet/README.md
@@ -1,0 +1,6 @@
+# Usage
+1. Copy file `override-example.yaml` into `override.yaml`.  Update values accordingly.
+1. Install the helm chart: `helm install -f /path/to/override.yaml --create-namespace --namespace scenario1 scenario1 ./bifrost-consensus-testnet`
+   1. To capture output from the orchestrator: `(DEMO_NAME=your-demo-name; helm upgrade --install -f ./helm/bifrost-consensus-testnet/override-example.yaml --namespace $DEMO_NAME --create-namespace $DEMO_NAME ./helm/bifrost-consensus-testnet/ &&  kubectl wait --timeout=-1s --for=condition=Ready pod/$DEMO_NAME-bifrost-consensus-testnet-orchestrator -n $DEMO_NAME && kubectl logs --follow $DEMO_NAME-bifrost-consensus-testnet-orchestrator -n $DEMO_NAME)`
+2. Observe the logs of each node the Kubernetes cluster in the `scenario1` namespace
+3. Terminate the scenario using  `helm delete -n scenario1 scenario1`

--- a/charts/bifrost-consensus-testnet/override-example.yaml
+++ b/charts/bifrost-consensus-testnet/override-example.yaml
@@ -1,0 +1,79 @@
+# These settings control where the results are published
+results:
+  # The Storage Bucket on Google Cloud
+  bucket: bifrost-topl-labs-testnet-scenario-results
+  # The prefix to apply to each uploaded file.  The scenario name is automatically applied as a suffix to this prefix.
+  prefix: /simulation/results/
+
+# These settings control the parameters of the scenario
+scenario:
+  # The height that must be reached by each node in the scenario
+  targetHeight: 30
+  # The number of transactions to generate and broadcast per second.  Transactions are broadcasted to nodes at random.
+  transactionsPerSecond: 2.5
+  # The maximum length of time to wait for an individual node to reach the target height.  If a node fails to reach
+  # the target height within this time, the scenario will still pass, but a log message will be presented
+  # indicating that it was terminated early.
+  timeout: 10 minutes
+
+# These settings will apply to the configurations of all nodes.
+shared-config:
+  # Define custom application.conf overrides
+  bifrost:
+    big-bang:
+      staker-count: 2
+    protocols:
+      0:
+        slot-duration: 250 milli
+
+# Define an entry for each node you wish to launch in the cluster
+configs:
+  # Name the node
+  producer0:
+    # Define custom application.conf overrides
+    bifrost:
+      big-bang:
+        local-staker-index: 0
+    # Define the network topology of this node
+    topology:
+      # Applies to all connections received by this node
+      ingress:
+        # The amount of throttling to impose on the local node's portion of the connection
+        throttle:
+          latency: 10 milli
+          downloadBytesPerSecond: 500000
+          uploadBytesPerSecond: 500000
+  producer1:
+    bifrost:
+      big-bang:
+        local-staker-index: 1
+    topology:
+      ingress:
+        throttle:
+          latency: 10 milli
+          downloadBytesPerSecond: 500000
+          uploadBytesPerSecond: 500000
+  relay0:
+    bifrost:
+      big-bang:
+        local-staker-index: -1
+    topology:
+      ingress:
+        throttle:
+          latency: 10 milli
+          downloadBytesPerSecond: 500000
+          uploadBytesPerSecond: 500000
+      # Outbound connections are defined here
+      egress:
+          # The name of the peer
+        - peer: producer0
+          # The amount of throttling to impose on the local node's portion of the connection
+          throttle:
+            latency: 10 milli
+            downloadBytesPerSecond: 500000
+            uploadBytesPerSecond: 500000
+        - peer: producer1
+          throttle:
+            latency: 10 milli
+            downloadBytesPerSecond: 500000
+            uploadBytesPerSecond: 500000

--- a/charts/bifrost-consensus-testnet/templates/_helpers.tpl
+++ b/charts/bifrost-consensus-testnet/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bifrost.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bifrost.fullname" -}}
+{{- if $.Values.fullnameOverride }}
+{{- $.Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name $.Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bifrost.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bifrost.labels" -}}
+helm.sh/chart: {{ include "bifrost.chart" . }}
+{{ include "bifrost.selectorLabels" . }}
+{{- if $.Chart.AppVersion }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ $.Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bifrost.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bifrost.name" . }}
+app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bifrost.serviceAccountName" -}}
+{{- if $.Values.serviceAccount.create }}
+{{- default (include "bifrost.fullname" .) $.Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" $.Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/bifrost-consensus-testnet/templates/bifrost/nodes.yaml
+++ b/charts/bifrost-consensus-testnet/templates/bifrost/nodes.yaml
@@ -1,0 +1,215 @@
+{{ $bigBangTimestamp := default (now | unixEpoch  | mul 1000 | add (default (len $.Values.configs | mul 15000) .Values.bigBang.delayMs)) .Values.bigBang.timestamp }}
+{{ $fullname := include "bifrost.fullname" . }}
+{{ $labels := include "bifrost.labels" . }}
+{{ $selectorLabels := include "bifrost.selectorLabels" . }}
+{{ $Values := .Values }}
+{{ $Release := .Release }}
+{{ range $nodeName, $value :=  $.Values.configs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullname }}-config-{{ $nodeName }}
+  labels:
+    {{ $labels | nindent 4 }}
+data:
+  shared.yaml: |
+    bifrost:
+      big-bang:
+        timestamp: {{ $bigBangTimestamp }}
+      data:
+        directory: /opt/docker/.bifrost/data
+      staking:
+        directory: /opt/docker/.bifrost/staking
+      p2p:
+        bind-host: localhost
+        bind-port: 9083
+      rpc:
+        bind-host: 0.0.0.0
+        bind-port: {{ $Values.service.ports.rpc }}
+  shared-user.yaml: |
+    {{- index $Values "shared-config" | toYaml | nindent 4}}
+  node.yaml: |
+    {{- toYaml $value | nindent 4 }}
+  peers.yaml: |
+    {{- $knownPeersString := "" -}}
+    {{ if $value.topology }}
+    {{ range $index, $peer := $value.topology.egress }}
+        {{- if $index }}{{ $knownPeersString = print $knownPeersString "," }}{{ end -}}
+    {{ $knownPeersString = print $knownPeersString "localhost:"}}
+    {{ $knownPeersString = print $knownPeersString (add 9100 $index)}}
+    {{ end }}
+    {{ end }}
+    {{ $knownPeersString = nospace $knownPeersString }}
+    bifrost:
+      p2p:
+        known-peers: "{{ $knownPeersString }}"
+  delayer.yaml: |
+    routes:
+      - bind-host: 0.0.0.0
+        bind-port: {{ $Values.service.ports.p2p }}
+        destination-host: localhost
+        destination-port: 9083
+        {{ if $value.topology }}
+        {{ if $value.topology.ingress }}
+        {{ if $value.topology.ingress.throttle }}
+        throttle:
+          latency: {{ $value.topology.ingress.throttle.latency }}
+          download-bytes-per-second: {{ $value.topology.ingress.throttle.downloadBytesPerSecond }}
+          upload-bytes-per-second: {{ $value.topology.ingress.throttle.uploadBytesPerSecond }}
+        {{ end }}
+        {{ end }}
+        {{ end }}
+    {{ if $value.topology }}
+    {{ range $index, $egress := $value.topology.egress }}
+      - bind-host: localhost
+        bind-port: {{ add 9100 $index }}
+        destination-host: {{ $fullname }}-p2p-{{ $egress.peer }}.{{ $Release.Name }}.svc.cluster.local
+        destination-port: {{ $Values.service.ports.p2p }}
+        {{ if $egress.throttle }}
+        throttle:
+          latency: {{ $egress.throttle.latency }}
+          download-bytes-per-second: {{ $egress.throttle.downloadBytesPerSecond }}
+          upload-bytes-per-second: {{ $egress.throttle.uploadBytesPerSecond }}
+        {{ end }}
+    {{ end }}
+    {{ end }}
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $fullname }}-{{ $nodeName }}
+  labels:
+    {{ $labels | nindent 4 }}
+spec:
+  serviceName: {{ $fullname }}-{{ $nodeName }}
+  replicas: 1
+  selector:
+    matchLabels:
+      node-name: {{ $nodeName }}
+      {{- $selectorLabels | nindent 6 }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        node-name: {{ $nodeName }}
+        {{- $selectorLabels | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml $Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: node
+          image: {{ $Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}
+          securityContext:
+            {{- toYaml $Values.securityContext | nindent 12 }}
+          command:
+          {{ range $Values.command }}
+            - {{ . }}
+          {{ end }}
+          args:
+            - --config
+            - /etc/config/shared.yaml
+            - --config
+            - /etc/config/shared-user.yaml
+            - --config
+            - /etc/config/node.yaml
+            - --config
+            - /etc/config/peers.yaml
+          resources:
+          {{- toYaml $Values.resources | nindent 12 }}
+        {{- if $Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              port: {{ $Values.service.ports.rpc }}
+            initialDelaySeconds: {{ $Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $Values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ $Values.readinessProbe.periodSeconds }}
+        {{- end }}
+        {{- if $Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              port: {{ $Values.service.ports.rpc }}
+            initialDelaySeconds: {{ $Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $Values.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ $Values.livenessProbe.periodSeconds }}
+        {{- end }}
+          ports:
+            - containerPort: {{ $Values.service.ports.rpc }}
+          volumeMounts:
+            - name: {{ $Values.name }}-pv-{{$nodeName}}
+              mountPath: {{ $Values.volume.mountDirectory }}
+            - name: config-map
+              mountPath: /etc/config
+        - name: network-delayer
+          image: {{ $Values.delayerImage.name }}:{{ $Values.delayerImage.tag }}
+          securityContext:
+            {{- toYaml $Values.securityContext | nindent 12 }}
+          args:
+            - --config
+            - /etc/config/delayer.yaml
+          resources:
+            limits:
+              cpu: 800m
+              memory: 384Mi
+            requests:
+              cpu: 200m
+              memory: 384Mi
+          ports:
+            - containerPort: {{ $Values.service.ports.p2p }}
+            {{- range $index, $peer := $value.peers }}
+            - containerPort: {{ add 9100 $index }}
+            {{ end }}
+          volumeMounts:
+            - name: config-map
+              mountPath: /etc/config
+      volumes:
+        - name: config-map
+          configMap:
+            name: {{ $fullname }}-config-{{ $nodeName }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ $Values.name }}-pv-{{$nodeName}}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ $Values.volume.storageClass }}
+        resources:
+          requests:
+            storage: {{ $Values.volume.storageSize }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname }}-rpc-{{ $nodeName }}
+  labels:
+    {{- $labels | nindent 4}}
+spec:
+  selector:
+    node-name: {{ $nodeName }}
+    {{- $selectorLabels | nindent 4 }}
+  type: {{ $Values.service.type }}
+  ports:
+    - protocol: TCP
+      name: rpc
+      port: {{ $Values.service.ports.rpc }}
+      targetPort: {{ $Values.service.ports.rpc }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname }}-p2p-{{ $nodeName }}
+  labels:
+    {{- $labels | nindent 4}}
+spec:
+  selector:
+    node-name: {{ $nodeName }}
+    {{- $selectorLabels | nindent 4 }}
+  type: {{ $Values.service.type }}
+  ports:
+    - protocol: TCP
+      name: p2p
+      port: {{ $Values.service.ports.p2p }}
+      targetPort: {{ $Values.service.ports.p2p }}
+---
+{{ end }}

--- a/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-config.yaml
+++ b/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-config.yaml
@@ -1,0 +1,28 @@
+{{ $fullname := include "bifrost.fullname" . }}
+{{ $labels := include "bifrost.labels" . }}
+{{ $Values := .Values }}
+{{ $Release := .Release }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullname }}-config-orchestrator
+  labels:
+    {{ $labels | nindent 4 }}
+data:
+  orchestrator.yaml: |
+    simulation-orchestrator:
+      kubernetes:
+        namespace: {{ .Release.Namespace }}
+      scenario:
+        target-height: {{ $Values.scenario.targetHeight }}
+        transactions-per-second: {{ $Values.scenario.transactionsPerSecond }}
+        timeout: {{ $Values.scenario.timeout }}
+      publish:
+        bucket: {{ $Values.results.bucket }}
+        file-prefix: {{ $Values.results.prefix }}{{ .Release.Name }}/
+      nodes:
+        {{ range $nodeName, $value :=  $.Values.configs }}
+        - name: {{ $nodeName }}
+          host: {{ $fullname }}-rpc-{{ $nodeName }}.{{ $Release.Name }}.svc.cluster.local
+          port: 9084
+        {{ end }}

--- a/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-pod.yaml
+++ b/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-pod.yaml
@@ -1,0 +1,41 @@
+{{ $fullname := include "bifrost.fullname" . }}
+{{ $labels := include "bifrost.labels" . }}
+{{ $Values := .Values }}
+{{ $Release := .Release }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ $fullname }}-orchestrator
+  labels:
+    {{ $labels | nindent 4 }}
+spec:
+  automountServiceAccountToken: true
+  serviceAccountName: {{ include "bifrost.serviceAccountName" . }}
+  securityContext:
+    {{- toYaml $Values.podSecurityContext | nindent 4 }}
+  containers:
+    - name: testnet-simulation-orchestrator
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      image: {{ $Values.orchestratorImage.name }}:{{ default .Chart.AppVersion .Values.orchestratorImage.tag }}
+      args:
+        - --config
+        - /etc/config/orchestrator.yaml
+      resources:
+        limits:
+          cpu: 1500m
+          memory: 1500Mi
+        requests:
+          cpu: 400m
+          memory: 1500Mi
+      volumeMounts:
+        - name: config-map
+          mountPath: /etc/config
+  volumes:
+    - name: config-map
+      configMap:
+        name: {{ $fullname }}-config-orchestrator

--- a/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-rb.yaml
+++ b/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-rb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "bifrost.fullname" . }}-rolebinding
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "bifrost.fullname" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bifrost.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-role.yaml
+++ b/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-role.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "bifrost.fullname" . }}-role
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec", "pods/status", "events", "secrets", "configmaps", "serviceaccounts", "namespaces"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
+{{- end }}

--- a/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-sa.yaml
+++ b/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-sa.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bifrost.serviceAccountName" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/bifrost-consensus-testnet/values.yaml
+++ b/charts/bifrost-consensus-testnet/values.yaml
@@ -1,0 +1,87 @@
+name: bifrost-consensus-testnet
+
+image:
+  #  name: bifrost-node
+  #  name: ghcr.io/topl/bifrost-node
+  name: ghcr.io/topl/bifrost-node
+  tag:
+
+delayerImage:
+  name: us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/network-delayers
+  tag:
+
+orchestratorImage:
+  name: us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/testnet-simulation-orchestrator
+  tag: latest
+
+bigBang:
+  timestamp:
+  delayMs:
+
+shared-config: {}
+configs: {}
+
+results:
+  bucket:
+  prefix: /simulation/results/
+
+scenario:
+  targetHeight: 30
+  transactionsPerSecond: 2.0
+  timeout: 10 minutes
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 1000Mi
+  requests:
+    cpu: 100m
+    memory: 1000Mi
+
+podSecurityContext:
+  runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.
+  runAsGroup: 0
+  fsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+args: []
+
+command:
+
+service:
+  type: ClusterIP
+  ports:
+    p2p: 9085
+    rpc: 9084
+
+volume:
+  mountDirectory: /opt/docker/.bifrost
+  storageClass:
+  storageSize: 1Gi
+
+livenessProbe:
+  enabled: false
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60
+
+readinessProbe:
+  enabled: false
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60
+
+serviceAccount:
+  create: true
+  name: bifrost-orchestrator-account
+
+rbac:
+  create: true

--- a/charts/bifrost-daml-broker/.helmignore
+++ b/charts/bifrost-daml-broker/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/bifrost-daml-broker/Chart.yaml
+++ b/charts/bifrost-daml-broker/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: bifrost-daml-broker
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0.beta-2"

--- a/charts/bifrost-daml-broker/templates/_helpers.tpl
+++ b/charts/bifrost-daml-broker/templates/_helpers.tpl
@@ -1,0 +1,97 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bifrost.daml.broker.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{- define "bifrost.daml.broker.config.name" -}}
+{{- include "bifrost.daml.broker.name"  . | printf "%s-config" -}}
+{{- end -}}
+{{- define "bifrost.daml.broker.secret.name" -}}
+{{- include "bifrost.daml.broker.name"  . | printf "%s-secret" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bifrost.daml.broker.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bifrost.daml.broker.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bifrost.daml.broker.labels" -}}
+helm.sh/chart: {{ include "bifrost.daml.broker.chart" . }}
+{{ include "bifrost.daml.broker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bifrost.daml.broker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bifrost.daml.broker.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bifrost.daml.broker.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bifrost.daml.broker.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the parameters to use
+*/}}
+{{- define "bifrost.daml.broker.daml.settings" -}}
+{{- if eq .Values.damlEnv "damlhub" -}}
+daml-host: {{ printf "%s.daml.app" .Values.damlDamlHubEnvConfig.ledgerId}}
+daml-port: "{{ .Values.damlDamlHubEnvConfig.damlPort }}"
+daml-secure: "{{ .Values.damlDamlHubEnvConfig.damlSecure }}"
+is-daml-hub: "true"
+{{- else -}}
+daml-host: {{ .Values.damlClusterEnvConfig.damlHost}}
+daml-port: "{{ .Values.damlClusterEnvConfig.damlPort }}"
+daml-secure: "{{ .Values.damlClusterEnvConfig.damlSecure }}"
+is-daml-hub: "false"
+{{- end -}}
+{{- end -}}
+
+{{- define "bifrost.daml.broker.topl.settings" -}}
+ {{- if eq .Values.toplEnv "valhalla" -}}
+network: {{ .Values.toplValhallaNetworkConfig.network }}
+bifrost-url: {{ .Values.toplValhallaNetworkConfig.bifrostUrl }}
+{{- else -}}
+network: {{ .Values.toplClusterNetworkConfig.network}}
+bifrost-url: {{ .Values.toplClusterNetworkConfig.bifrostUrl }}
+{{- end -}}   
+{{- end -}}

--- a/charts/bifrost-daml-broker/templates/configmap.yaml
+++ b/charts/bifrost-daml-broker/templates/configmap.yaml
@@ -1,0 +1,9 @@
+# a config map for the broker
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bifrost.daml.broker.config.name" . }}
+data:
+  {{ include "bifrost.daml.broker.daml.settings" . | nindent 2 }}
+  {{ include "bifrost.daml.broker.topl.settings" . | nindent 2 }}

--- a/charts/bifrost-daml-broker/templates/deployment.yaml
+++ b/charts/bifrost-daml-broker/templates/deployment.yaml
@@ -1,0 +1,112 @@
+# a k8 deployment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bifrost.daml.broker.fullname" . }}
+  labels:
+    app: {{ include "bifrost.daml.broker.fullname" . }}
+spec:
+  replicas:  {{ .Values.replicaCount }}
+  selector:
+    matchLabels: 
+      app: {{ include "bifrost.daml.broker.fullname" . }}
+  template:
+    metadata:
+      labels: 
+        app: {{ include "bifrost.daml.broker.fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image:  {{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        args: 
+          - "--"
+          - "-t"
+          - "$(DAML_ACCESS_TOKEN)"
+          - "-n"
+          - "$(NETWORK)"
+          - "-u"
+          - "$(URL)"
+          - "-h"
+          - "$(DAML_HOST)"
+          - "-p"
+          - "$(DAML_PORT)"
+          - "-o"
+          - "$(DAML_PARTY)"
+          - "-s"
+          - "$(DAML_SECURE)"
+          - "-k"
+          - "$(TOPL_KEYFILE)"
+          - "-m"
+          - "$(IS_DAML_HUB)"
+          - "-w"
+          - "$(TOPL_KEYFILE_PASSWORD)"
+          - "-a"
+          - "$(TOPL_API_KEY)"
+        resources:
+          limits:
+            cpu: {{ .Values.resources.limits.cpu }}
+            memory: {{ .Values.resources.limits.memory }}
+        env:
+          - name: NETWORK
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "bifrost.daml.broker.config.name" . }}
+                key: network
+          - name: URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "bifrost.daml.broker.config.name" . }}
+                key: bifrost-url
+          - name: DAML_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "bifrost.daml.broker.config.name" . }}
+                key: daml-host
+          - name: DAML_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "bifrost.daml.broker.config.name" . }}
+                key: daml-port
+          - name: IS_DAML_HUB
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "bifrost.daml.broker.config.name" . }}
+                key: is-daml-hub
+          - name: DAML_SECURE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "bifrost.daml.broker.config.name" . }}
+                key: daml-secure
+          - name: DAML_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "bifrost.daml.broker.secret.name" . }}
+                key: daml-token
+          - name: DAML_PARTY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "bifrost.daml.broker.secret.name" . }}
+                key: daml-party
+          - name: TOPL_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "bifrost.daml.broker.secret.name" . }}
+                key: topl-api-key
+          - name: TOPL_KEYFILE
+            value: /broker/keyfile.json
+          - name: TOPL_KEYFILE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "bifrost.daml.broker.secret.name" . }}
+                key: topl-keyfile-password
+        volumeMounts:
+        - name: broker-config
+          mountPath: /broker/
+      volumes:
+        - name: broker-config
+          secret:
+            secretName: {{ include "bifrost.daml.broker.secret.name" . }}
+            items:
+            - key: topl-keyfile
+              path: keyfile.json

--- a/charts/bifrost-daml-broker/values.yaml
+++ b/charts/bifrost-daml-broker/values.yaml
@@ -1,0 +1,45 @@
+# Default values for helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+name: bifrost-daml-broker
+
+damlEnv: damlhub # possible values: dalmhub, cluster
+
+toplEnv: valhalla # possible values: valhalla, cluster
+
+damlDamlHubEnvConfig:
+  ledgerId: w85m150i4gbsvl9m
+  damlPort: "443"
+  damlSecure: "true"
+
+damlClusterEnvConfig:
+  damlHost: canton-and-topl-service
+  damlPort: "5011"
+  damlSecure: "true"
+
+toplValhallaNetworkConfig:
+  network: valhalla
+  bifrostUrl: https://vertx.topl.services/valhalla/63ed2dbf5ef2c40011c59cf2
+
+toplClusterNetworkConfig:
+  network: private
+  bifrostUrl: http://localhost:9085
+
+resources:
+  limits:
+    cpu: "2"
+    memory: "1024Mi"
+
+image:
+  name: toplprotocol/bifrost-daml-broker
+  tag:
+
+replicaCount: 1
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL

--- a/charts/bifrost/.helmignore
+++ b/charts/bifrost/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: bifrost
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "2.0.0-alpha1"
+
+#TODO: Find a better icon.
+icon: https://uploads-ssl.webflow.com/60f98f46d44e675abb7e66ea/611c4d83ed3df101fd221875_topl_basew.svg

--- a/charts/bifrost/templates/_helpers.tpl
+++ b/charts/bifrost/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bifrost.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bifrost.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bifrost.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bifrost.labels" -}}
+helm.sh/chart: {{ include "bifrost.chart" . }}
+{{ include "bifrost.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bifrost.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bifrost.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bifrost.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bifrost.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/bifrost/templates/bifrost/deployment.yaml
+++ b/charts/bifrost/templates/bifrost/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "bifrost.fullname" . }}-p2p
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "bifrost.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "bifrost.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        command:
+          {{ range .Values.command }}
+            - {{ . }}
+          {{ end }}
+        args:
+          {{ range .Values.args }}
+            - {{ . }}
+          {{ end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.ports.rpc }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+        {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            port: {{ .Values.ports.rpc }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.ports.p2p }}
+        - containerPort: {{ .Values.ports.rpc }}
+        volumeMounts:
+        - name: {{ .Values.name }}-pv
+          mountPath: {{ .Values.volume.mountDirectory }}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ .Values.name }}-pv
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.volume.storageClass }}
+      resources:
+        requests:
+          storage: {{ .Values.volume.storageSize }}

--- a/charts/bifrost/templates/bifrost/service.yaml
+++ b/charts/bifrost/templates/bifrost/service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4}}
+spec:
+  selector:
+    {{- include "bifrost.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+  ports:
+    - protocol: TCP
+      name: rpc
+      port: {{ .Values.service.ports.rpc }}
+      targetPort: {{ .Values.ports.rpc }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bifrost.fullname" . }}-p2p
+  labels:
+    {{- include "bifrost.labels" . | nindent 4}}
+spec:
+  selector:
+    {{- include "bifrost.selectorLabels" . | nindent 4 }}
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      name: p2p
+      port: {{ .Values.service.ports.p2p }}
+      targetPort: {{ .Values.ports.p2p }}
+{{- end }}

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -1,0 +1,69 @@
+# # Default values for bifrost.
+# # This is a YAML-formatted file.
+# # Declare variables to be passed into your templates.
+
+name: bifrost-node
+
+image:
+  name: ghcr.io/topl/bifrost-node
+  tag:
+
+replicas: 1
+
+resources:
+  limits:
+    cpu: 2.0
+    memory: 4000Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+podSecurityContext:
+  runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.
+  runAsGroup: 0
+  fsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+args: # Refer to CLI: https://github.com/Topl/Bifrost#command-line-reference
+# args: ['--seed', 'test', '--forge']
+# args: ['--network', 'valhalla']
+
+command:
+# command: ["tail", "-f", "/dev/null"] # Use this to debug Bifrost and exec into the running pod.
+
+service:
+  enabled: true
+  type: ClusterIP
+  ports:
+    p2p: 9084
+    rpc: 9085
+
+ports:
+  p2p: 9084
+  rpc: 9085
+
+volume:
+  mountDirectory: /opt/docker/.bifrost
+  # GKE specific storage classes: standard, standard-rwo, premium-rwo
+  storageClass: default
+  storageSize: 10Gi
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60 # Perform check every x seconds.
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 60 # Perform check every x seconds.


### PR DESCRIPTION
## Purpose
Follow conventions of having a Git repo for managing our helm charts.

This allows us to use the GitHub pages feature to host the helm chart repo and allow others to utilize our charts.

## Approach
Move the following charts:
* bifrost
* bifrost-consensus-testnet
* bifrost-daml-broker

Also add a GitHub action to release the charts and host them via GitHub pages.

I also updated the image tags to default to the chart app version, but still allow the ability to override in the `values.yaml` file.

## Testing
🚀 https://topl.github.io/helm-charts/

![image](https://user-images.githubusercontent.com/17308716/221233553-4fc8cb4b-62f0-48cb-8849-d968d5010c24.png)
