### PR TITLE
Bump versions of the charts to fix publishing issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Purpose
+
+## Approach
+
+## Testing
+
+Checklist:
+
+* [ ] I have bumped the chart version.
+* [ ] Any new values are backwards compatible and/or have sensible default.
+
+Changes are automatically published when merged to `main`. They are not published on branches.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Info on formatting this file at
+# https://blog.github.com/2017-07-06-introducing-code-owners/
+
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @admiraladmirable @rach-tech

--- a/charts/bifrost-consensus-testnet/Chart.yaml
+++ b/charts/bifrost-consensus-testnet/Chart.yaml
@@ -4,7 +4,7 @@ description: Launches a private testnet using configurable nodes and artificial 
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
 appVersion: "2.0.0-alpha1"
 

--- a/charts/bifrost-daml-broker/Chart.yaml
+++ b/charts/bifrost-daml-broker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
The publish step has failed the last few times: https://github.com/Topl/helm-charts/actions/runs/4266054409

I also added a PR template to indicate the need to bump the necessary chart versions similarly to how it's done in Argo: https://github.com/argoproj/argo-helm/tree/main

I also added a codeowners file to reduce the need to manually add reviewers.