### PR TITLE
Update Testnet Resources

### DIFF
--- a/charts/bifrost-consensus-testnet/Chart.yaml
+++ b/charts/bifrost-consensus-testnet/Chart.yaml
@@ -4,7 +4,7 @@ description: Launches a private testnet using configurable nodes and artificial 
 
 type: application
 
-version: 0.1.1
+version: 0.1.2
 
 appVersion: "2.0.0-alpha1"
 

--- a/charts/bifrost-consensus-testnet/templates/bifrost/nodes.yaml
+++ b/charts/bifrost-consensus-testnet/templates/bifrost/nodes.yaml
@@ -119,7 +119,7 @@ spec:
             - --config
             - /etc/config/peers.yaml
           resources:
-          {{- toYaml $Values.resources | nindent 12 }}
+          {{- toYaml $Values.resources.node | nindent 12 }}
         {{- if $Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
@@ -151,12 +151,7 @@ spec:
             - --config
             - /etc/config/delayer.yaml
           resources:
-            limits:
-              cpu: 800m
-              memory: 384Mi
-            requests:
-              cpu: 200m
-              memory: 384Mi
+          {{- toYaml $Values.resources.networkDelayer | nindent 12 }}
           ports:
             - containerPort: {{ $Values.service.ports.p2p }}
             {{- range $index, $peer := $value.peers }}

--- a/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-pod.yaml
+++ b/charts/bifrost-consensus-testnet/templates/orchestrator/orchestrator-pod.yaml
@@ -26,12 +26,7 @@ spec:
         - --config
         - /etc/config/orchestrator.yaml
       resources:
-        limits:
-          cpu: 1500m
-          memory: 1500Mi
-        requests:
-          cpu: 400m
-          memory: 1500Mi
+      {{- toYaml $Values.resources.orchestrator | nindent 8 }}
       volumeMounts:
         - name: config-map
           mountPath: /etc/config

--- a/charts/bifrost-consensus-testnet/values.yaml
+++ b/charts/bifrost-consensus-testnet/values.yaml
@@ -31,12 +31,28 @@ scenario:
   timeout: 10 minutes
 
 resources:
-  limits:
-    cpu: 2000m
-    memory: 1000Mi
-  requests:
-    cpu: 100m
-    memory: 1000Mi
+  node:
+    limits:
+      cpu: 2000m
+      memory: 1000Mi
+    requests:
+      cpu: 1000m
+      memory: 1000Mi
+  orchestrator:
+    limits:
+      cpu: 1500m
+      memory: 1500Mi
+    requests:
+      cpu: 500m
+      memory: 1500Mi
+  networkDelayer:
+    limits:
+      cpu: 800m
+      memory: 768Mi
+    requests:
+      cpu: 200m
+      memory: 768Mi
+
 
 podSecurityContext:
   runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.


### PR DESCRIPTION
## Purpose
- Orchestrator and Network Delayer resources are not configurable
- Network Delayer's memory allocation is too low for high network delay
## Approach
- Add values.yaml configs for Orchestrator and Network Delayer resources
- Update network delayer memory allocation
- Update Node CPU requests
## Testing
- Testnet simulation in a Codespace
## Checklist:
* [Yes] I have bumped the chart version.
* [:shrug:] Any new values are backwards compatible and/or have sensible default.