### PR TITLE
[BN-1012]: Annulus Helm Chart

### DIFF
--- a/charts/annulus/.helmignore
+++ b/charts/annulus/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/annulus/Chart.yaml
+++ b/charts/annulus/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: Helm Chart for deploying Annulus, a Topl blockchain explorer.
+name: annulus
+type: application
+version: 0.1.0

--- a/charts/annulus/README.md
+++ b/charts/annulus/README.md
@@ -1,0 +1,119 @@
+# Ingress Service Helm Chart
+
+This Helm chart installs a service in both Kubernetes and Istio, and exposes
+it outside the cluster via an Istio ingress gateway.
+
+## Installation
+
+```sh
+> helm template --namespace=[namespace] [chartname] | kubectl apply -f -
+```
+
+## Values.yaml
+
+All configuration for this installation is managed in `values.yaml`. Configuration
+values can be overriden individually at installation using Helm's `--set` command
+line option.
+
+### Service Identity
+
+These three values control the names of generated Kubernetes and Istio objects,
+and are used to ensure commont Kubernetes labeling. These values are used to populate
+labels that allow for selecting all components of a particular system or service.
+
+* `system`, `service`, `version` - These values describe _what_ this service and
+  what it should be named. For example: `my-website`, `web-server`, `2`.
+
+### Container Values
+
+These settings control from where and how your service's docker image is acquired.
+
+* `image.repository` - The docker repo and image to pull.
+* `image.tag` - The docker image tag to pull.
+* `image.imagePullPolicy` - Kubernetes image pull policy.
+
+### Service Account Values
+
+Istio request authorization requires that each service have a unique service account
+identity to functuion correctly.
+
+* `serviceAccount.name` - The Kubernetes service account your service will run under.
+* `serviceAccount.create` - Optionally, this chart can generate the service account.
+  If false, the service's service account must be pre-existing.
+
+### Replica Values
+
+These settings control service replicas, disruption budgets, and autoscaling.
+
+* `replicaCount` - The initial number of replicas to start after installing this
+  chart.
+* `maxUnavailable` - The maximum number of intentionally unavailable pods as
+  controlled by a `PodDisruptionBudget`.
+* `autoscaling.minReplicas` - The minimum number of replicas to run under the
+  control of a `HorizontalPodAutoscaler`.
+* `autoscaling.maxReplicas` - The maximum number of replicas to run under the
+  control of a `HorizontalPodAutoscaler`.
+* `autoscaling.targetAverageCpuUtilization` - The CPU utilization target
+  used by the `HorizontalPodAutoscaler` to make autoscale decisions.
+
+### Port Values
+
+These settings expose network ports through Kubernetes and Istio. Ports are
+listed as an array.
+
+* `ports.name` - The unique name for this port. Port names _should_ comply
+  with Istio port naming standards by including their protocol in the name.
+  Protocol detection works for HTTP and HTTP/2, but other protocols need help.
+  <https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/>
+* `ports.port` - The port number presented _outside_ your container. This is the
+  port Istio and Kubernetes will use when referring to your service's port.
+* `ports.targetPort` - The internal port number _inside_ your container. Kubernetes
+  will map the outside port to the inside port when routing traffic to your container.
+
+### Ingress Values
+
+These settings configure how Istio exposes your service throug an Istio ingress
+gateway. They assume the Istio ingress gateway is installed, and an Istio
+`Gateway` object has been configured in the mesh.
+
+* `ingressGateway.name` - The namespace/name of the Istio `Gateway` object through
+  which this service should be exposed.
+* `ingressGateway.host` - Bind this service's ingress configuration to a hostname.
+* `ingressGateway.matchPrefix` - A string array of REST route prefixes this service
+  matches. gRPC services are matched as `/protoNamespace/protoService/*`.
+
+### Resiliency Values
+
+These settings control Istio's resiliency configuration for your service. This
+includes timeouts, circuit breakers, retires, and outlier detection.
+
+* `overallTimeout` - The "top-level" timeout enforced when clients call your
+  service. This timeout is inclusive of retries.
+* `retries.*` - Istio configuration for client retry policy. See
+  [Istio retry documentation](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRetry) for values. Note: if retries are configured,
+  an `overallTimeout` greater than the sum of all retries must be used.
+* `outlierDetection.*` - Istio configuration for client circuit breaker configuration.
+  See [Istio outlier detection documentation](https://istio.io/latest/docs/reference/config/networking/destination-rule/#OutlierDetection) for details.
+
+### Kubernetes Pod Values
+
+These settings configure your service's resource constraints and health check
+probes. They ensure your service is a well behaved consumer of shared Kubernetes
+resources.
+
+* `resources.*` - Kubernetes resource request and limit configuration. See
+  [Kubernetes resource documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for values.
+* `probes.*` - Kubernetes probe configuration. See [Kubernetes probe documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for values.
+
+### ConfigMap Values
+
+These optional settings are used to populate and mount a configmap for your
+service. When the generated config map changes, the associated service is automatically
+resterted using a rolling restart. Generating the configmap from Helm chart values
+is useful because it allows you to modify config map values durring installation
+using Helm `--set` directives.
+
+* `configMap.mountPath` - The directory inside your pod to mount the config map.
+* `configMap.fileName` - The file name of the config map, when mounted in the pod.
+* `configMap.content.*` - YAML keys and values under `content` are copied verbatim
+  into the configmap's content.

--- a/charts/annulus/templates/configmap.yaml
+++ b/charts/annulus/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.configMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.service | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  {{ .Values.configMap.fileName | default "config.yaml" }}: |-
+{{ toYaml .Values.configMap.content | indent 4 }}
+{{- end }}

--- a/charts/annulus/templates/deployment.yaml
+++ b/charts/annulus/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.service | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.service | lower | quote }}
+      version: {{ .Values.version | quote }}
+  template:
+    metadata:
+      labels:
+        # Kubernetes recommended labels
+        app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+        app.kubernetes.io/part-of: {{ .Values.system | quote }}
+        app.kubernetes.io/version: {{ .Values.version | quote }}
+        # Isio required labels
+        app: {{ .Values.service | lower | quote }}
+        version: {{ .Values.version | quote }}
+{{- if .Values.configMap }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name | lower | quote }}
+      containers:
+        - name: {{ .Values.service | lower | quote }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
+          ports:
+{{- range .Values.ports }}
+            - name: {{ .name | quote }}
+              containerPort: {{ .targetPort }}
+              protocol: TCP
+{{- end }}
+{{- if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}
+{{- if .Values.probes }}
+{{ toYaml .Values.probes | indent 10 }}
+{{- end }}
+{{- if .Values.configMap }}
+          volumeMounts:
+            - name: {{ (print .Values.service "-config") | quote }}
+              mountPath: {{ .Values.configMap.mountPath | quote }}
+      volumes:
+        - name: {{ (print .Values.service "-config") | quote }}
+          configMap:
+            name: {{ .Values.service | lower | quote }}
+{{- end }}

--- a/charts/annulus/templates/deployment.yaml
+++ b/charts/annulus/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name | lower | quote }}
       containers:
         - name: {{ .Values.service | lower | quote }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           ports:
 {{- range .Values.ports }}

--- a/charts/annulus/templates/destinationRule.yaml
+++ b/charts/annulus/templates/destinationRule.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: {{ .Values.service | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  host: {{ (print .Values.service "." .Release.Namespace ".svc.cluster.local")  | quote }}
+{{- if .Values.outlierDetection }}
+  trafficPolicy:
+    outlierDetection:
+{{ toYaml .Values.outlierDetection | indent 6 }}
+{{- end }}
+  subsets:
+    - name: {{ (print "v" .Values.version) | quote }}
+      labels:
+        version: {{ .Values.version | quote }}

--- a/charts/annulus/templates/horizontalPodAutoscaler.yaml
+++ b/charts/annulus/templates/horizontalPodAutoscaler.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.autoscaling }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+    name: {{ .Values.service | lower | quote }}
+    labels:
+        app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+        app.kubernetes.io/part-of: {{ .Values.system | quote }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    namespace: {{ .Release.Namespace | quote }}
+spec:
+    scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: {{ .Values.service | lower | quote }}
+    minReplicas: {{ .Values.autoscaling.minReplicas }}
+    maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+    metrics:
+        - type: Resource
+          resource:
+              name: cpu
+              target:
+                  type: Utilization
+                  averageUtilization: {{ .Values.autoscaling.targetAverageCpuUtilization }}
+{{- end }}

--- a/charts/annulus/templates/podDisruptionBudget.yaml
+++ b/charts/annulus/templates/podDisruptionBudget.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.service | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+spec:
+  maxUnavailable: {{ .Values.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ .Values.service | lower | quote }}
+      version: {{ .Values.version | quote }}

--- a/charts/annulus/templates/service.yaml
+++ b/charts/annulus/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  ports:
+{{- range .Values.ports }}
+    - name: {{ .name | quote }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: TCP
+{{- end }}
+  selector:
+    app: {{ .Values.service | lower | quote }}

--- a/charts/annulus/templates/serviceAccount.yaml
+++ b/charts/annulus/templates/serviceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.serviceAccount.name | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end }}

--- a/charts/annulus/templates/virtualService.yaml
+++ b/charts/annulus/templates/virtualService.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ .Values.service | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  gateways:
+    - {{ .Values.ingressGateway.name | quote }} 
+  hosts:
+    - {{ .Values.ingressGateway.host | quote }}
+  http:
+    - match:
+{{- range .Values.ingressGateway.matchPrefix }}
+      - uri:
+          prefix: {{ . | quote }}
+{{- end }}
+      route:
+      - destination:
+          host: {{ (print .Values.service "." .Release.Namespace ".svc.cluster.local") | quote }}
+          subset: {{ (print "v" .Values.version) | quote }}
+{{- if .Values.retries }}
+      retries:
+{{ toYaml .Values.retries | indent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" .Values.overallTimeout}}
+{{- else if .Values.overallTimeout }}
+      timeout: {{ .Values.overallTimeout }}
+{{- end }}

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -49,7 +49,7 @@ ports:
 # above.
 ingressGateway:
   name: istio-gateways/bifrost-gateway
-  host: dev.annulus.topl.tech
+  host: annulus.dev.topl.tech
   matchPrefix:
     - "/"
 

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -42,7 +42,7 @@ ports:
     targetPort: 80
   - name: https-svc
     port: 443
-    targetPort: 8443
+    targetPort: 80
 
 # Configure the Istio ingress gateway to route outside traffic for the provided
 # host name to this service on the ports and protocols defined in the 'ports' section

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -76,7 +76,7 @@ resources:
     cpu: "200m"
   limits:
     memory: "64Mi"
-    cpu: "250M"
+    cpu: "250m"
 # Probe settings (use Kubernetes syntax)
 # Optional
 # probes:

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -39,6 +39,7 @@ autoscaling:
 ports:
   - name: http-svc
     port: 80
+    targetPort: 80
   - name: https-svc
     port: 443
     targetPort: 8443

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -1,0 +1,100 @@
+# Default values for annulus.
+# This is a YAML-formatted file.
+
+# The overall system your service is a part of
+system: annulus
+# The name of your service
+service: annulus
+# The major version number for your service
+version: 1
+
+# Docker settings
+image:
+  # The name of your docker container
+  repository: toplprotocol/annulus
+  # Your docker container's tag
+  tag:
+  imagePullPolicy: IfNotPresent
+
+# Istio uses the service account name as a component of the service's security
+# identity. Set "create" to false to use an previously created service account.
+serviceAccount:
+  name: annulus
+  create: true
+
+# The initial number of pod replicas to run for your service
+replicaCount: 1
+# The maximum number of pods from that set that can be unavailable at once
+maxUnavailable: 1
+
+# Horizontal pod autoscaler configuration (optional)
+autoscaling:
+  minReplicas: 1
+  maxReplicas: 5
+  targetAverageCpuUtilization: 80
+
+# Port settings
+# Ports must be named <protocol>[-<suffix>] to work with Istio.
+# Valid protocols are grpc, http, http2, https, mongo, mysql, redis, tcp, tls, udp
+ports:
+  - name: http-svc
+    port: 80
+  - name: https-svc
+    port: 443
+    targetPort: 8443
+
+# Configure the Istio ingress gateway to route outside traffic for the provided
+# host name to this service on the ports and protocols defined in the 'ports' section
+# above.
+ingressGateway:
+  name: istio-gateways/bifrost-gateway
+  host: dev.annulus.topl.tech
+  matchPrefix:
+    - "/"
+
+# The overall timeout for requests to this service
+# Optional
+overallTimeout: 10s
+
+# Client retry settings (use Istio syntax)
+# Optional
+retries:
+  attempts: 3
+  perTryTimeout: 2s
+
+# Circuit breaker settings (use Istio syntax)
+# Optional
+outlierDetection:
+  consecutive5xxErrors: 5
+
+# Resource settings (use Kubernetes syntax)
+# Optional
+resources:
+  requests:
+    memory: "32Mi"
+    cpu: "200m"
+  limits:
+    memory: "64Mi"
+    cpu: "250M"
+# Probe settings (use Kubernetes syntax)
+# Optional
+# probes:
+#   livenessProbe:
+#     initialDelaySeconds: 30
+#     httpGet:
+#       path: /health
+#       port: 8080
+#   readinessProbe:
+#     timeoutSeconds: 10
+#     httpGet:
+#       path: /ready
+#       port: 8080
+
+# configMap: # Optional
+#   # Where the config map should be mounted inside your container's filesystem.
+#   mountPath: /config/annulus-config
+#   fileName: config.yaml
+#   # Everything under content is copied verbatim into your service's configmap.
+#   content:
+#     key1: value1
+#     key2: value2


### PR DESCRIPTION
## Purpose
Create Helm chart for Annulus to facilitate deployment.

## Approach
* Use [Salesforce Istio Starter](https://github.com/salesforce/helm-starter-istio) as Helm template. 
* Change Docker image to use Annulus.

Note: The integration to Genus is still in work, so I will need to add parameters in the future to point to the Genus url. 

## Testing
Deployed to GCP.

Checklist:

* [ ] I have bumped the chart version.
* [ ] Any new values are backwards compatible and/or have sensible default.

Changes are automatically published when merged to `main`. They are not published on branches.