### PR TITLE
[BN-1146]: Resolve Gatekeeper Concerns for Helm Charts

### DIFF
--- a/charts/annulus/Chart.yaml
+++ b/charts/annulus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v0.5
+appVersion: v1.0
 description: Helm Chart for deploying Annulus, a Topl blockchain explorer.
 name: annulus
 type: application
-version: 0.1.3
+version: 0.1.4

--- a/charts/annulus/README.md
+++ b/charts/annulus/README.md
@@ -1,6 +1,6 @@
 # annulus
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5](https://img.shields.io/badge/AppVersion-v0.5-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0](https://img.shields.io/badge/AppVersion-v1.0-informational?style=flat-square)
 
 Helm Chart for deploying Annulus, a Topl blockchain explorer.
 
@@ -11,6 +11,9 @@ Helm Chart for deploying Annulus, a Topl blockchain explorer.
 | autoscaling.maxReplicas | int | `5` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetAverageCpuUtilization | int | `80` |  |
+| configMap.content | string | `"worker_processes  auto;\n\nerror_log  /tmp/nginx/error.log warn;\npid        /tmp/nginx/nginx.pid;\n\nevents {\n    worker_connections  1024;\n}\n\nhttp {\n    default_type  application/octet-stream;\n\n    log_format  main  '$remote_addr - $remote_user [$time_local] \"$request\" '\n                      '$status $body_bytes_sent \"$http_referer\" '\n                      '\"$http_user_agent\" \"$http_x_forwarded_for\"';\n\n    access_log  /var/log/nginx/access.log  main;\n\n    sendfile        on;\n    #tcp_nopush     on;\n\n    keepalive_timeout  65;\n\n    #gzip  on;\n\n    include /etc/nginx/conf.d/*.conf;\n\n    server {\n      listen 9999;\n      location /healthz {\n        access_log          off;\n        return              200;\n      }\n    }\n}\n"` |  |
+| configMap.fileName | string | `"nginx.conf"` |  |
+| configMap.mountPath | string | `"/etc/nginx"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"toplprotocol/annulus"` |  |
 | image.tag | string | `nil` |  |
@@ -18,20 +21,35 @@ Helm Chart for deploying Annulus, a Topl blockchain explorer.
 | ingressGateway.matchPrefix[0] | string | `"/"` |  |
 | ingressGateway.name | string | `"istio-gateways/bifrost-gateway"` |  |
 | maxUnavailable | int | `1` |  |
-| networkPolicy.enabled | bool | `true` |  |
 | outlierDetection.consecutive5xxErrors | int | `5` |  |
 | overallTimeout | string | `"10s"` |  |
+| podSecurityContext.fsGroup | int | `101` |  |
+| podSecurityContext.runAsGroup | int | `101` |  |
+| podSecurityContext.runAsUser | int | `101` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| podSecurityContext.supplementalGroups[0] | int | `101` |  |
 | ports[0].name | string | `"https-svc"` |  |
 | ports[0].port | int | `443` |  |
-| ports[0].targetPort | int | `80` |  |
+| ports[0].targetPort | int | `9999` |  |
+| probes.livenessProbe.httpGet.path | string | `"/healthz"` |  |
+| probes.livenessProbe.httpGet.port | int | `9999` |  |
+| probes.livenessProbe.initialDelaySeconds | int | `30` |  |
+| probes.readinessProbe.httpGet.path | string | `"/healthz"` |  |
+| probes.readinessProbe.httpGet.port | int | `9999` |  |
+| probes.readinessProbe.timeoutSeconds | int | `10` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"250m"` |  |
-| resources.limits.memory | string | `"64Mi"` |  |
+| resources.limits.ephemeral-storage | string | `"500Mi"` |  |
+| resources.limits.memory | string | `"500Mi"` |  |
 | resources.requests.cpu | string | `"200m"` |  |
 | resources.requests.memory | string | `"32Mi"` |  |
 | retries.attempts | int | `3` |  |
 | retries.perTryTimeout | string | `"2s"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | service | string | `"annulus"` |  |
+| serviceAccount.automountToken | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `"annulus"` |  |
 | system | string | `"annulus"` |  |

--- a/charts/annulus/templates/configmap.yaml
+++ b/charts/annulus/templates/configmap.yaml
@@ -10,5 +10,5 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 data:
   {{ .Values.configMap.fileName | default "config.yaml" }}: |-
-{{ toYaml .Values.configMap.content | indent 4 }}
+{{ .Values.configMap.content | indent 4 }}
 {{- end }}

--- a/charts/annulus/templates/deployment.yaml
+++ b/charts/annulus/templates/deployment.yaml
@@ -29,9 +29,14 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name | lower | quote }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
       containers:
         - name: {{ .Values.service | lower | quote }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           ports:
 {{- range .Values.ports }}
@@ -46,12 +51,22 @@ spec:
 {{- if .Values.probes }}
 {{ toYaml .Values.probes | indent 10 }}
 {{- end }}
-{{- if .Values.configMap }}
           volumeMounts:
+{{- if .Values.configMap }}
             - name: {{ (print .Values.service "-config") | quote }}
               mountPath: {{ .Values.configMap.mountPath | quote }}
+{{- end }}
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: tmp
+              mountPath: /tmp/nginx
       volumes:
+{{- if .Values.configMap }}
         - name: {{ (print .Values.service "-config") | quote }}
           configMap:
             name: {{ .Values.service | lower | quote }}
 {{- end }}
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/charts/annulus/templates/serviceAccount.yaml
+++ b/charts/annulus/templates/serviceAccount.yaml
@@ -7,4 +7,5 @@ metadata:
     app.kubernetes.io/name: {{ .Values.serviceAccount.name | lower | quote }}
     app.kubernetes.io/part-of: {{ .Values.system | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
 {{- end }}

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -21,6 +21,7 @@ image:
 serviceAccount:
   name: annulus
   create: true
+  automountToken: false
 
 # The initial number of pod replicas to run for your service
 replicaCount: 1
@@ -39,7 +40,7 @@ autoscaling:
 ports:
   - name: https-svc
     port: 443
-    targetPort: 80
+    targetPort: 9999
 
 # Configure the Istio ingress gateway to route outside traffic for the provided
 # host name to this service on the ports and protocols defined in the 'ports' section
@@ -72,29 +73,75 @@ resources:
     memory: "32Mi"
     cpu: "200m"
   limits:
-    memory: "64Mi"
+    memory: "500Mi"
     cpu: "250m"
-# Probe settings (use Kubernetes syntax)
-# Optional
-# probes:
-#   livenessProbe:
-#     initialDelaySeconds: 30
-#     httpGet:
-#       path: /health
-#       port: 8080
-#   readinessProbe:
-#     timeoutSeconds: 10
-#     httpGet:
-#       path: /ready
-#       port: 8080
+    ephemeral-storage: "500Mi"
 
-networkPolicy:
-  enabled: true
-# configMap: # Optional
-#   # Where the config map should be mounted inside your container's filesystem.
-#   mountPath: /config/annulus-config
-#   fileName: config.yaml
-#   # Everything under content is copied verbatim into your service's configmap.
-#   content:
-#     key1: value1
-#     key2: value2
+podSecurityContext:
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  supplementalGroups: [101]
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+# Probe settings (use Kubernetes syntax)
+probes:
+  livenessProbe:
+    initialDelaySeconds: 30
+    httpGet:
+      path: /healthz
+      port: 9999
+  readinessProbe:
+    timeoutSeconds: 10
+    httpGet:
+      path: /healthz
+      port: 9999
+
+configMap: # Optional
+  # Where the config map should be mounted inside your container's filesystem.
+  mountPath: /etc/nginx
+  fileName: nginx.conf
+  # Everything under content is copied verbatim into your service's configmap.
+  content: |
+    worker_processes  auto;
+
+    error_log  /tmp/nginx/error.log warn;
+    pid        /tmp/nginx/nginx.pid;
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /var/log/nginx/access.log  main;
+
+        sendfile        on;
+        #tcp_nopush     on;
+
+        keepalive_timeout  65;
+
+        #gzip  on;
+
+        include /etc/nginx/conf.d/*.conf;
+
+        server {
+          listen 9999;
+          location /healthz {
+            access_log          off;
+            return              200;
+          }
+        }
+    }

--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -1,6 +1,6 @@
 # bifrost
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha7](https://img.shields.io/badge/AppVersion-2.0.0--alpha7-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha7](https://img.shields.io/badge/AppVersion-2.0.0--alpha7-informational?style=flat-square)
 
 A Helm chart for Bifrost, the Topl blockchain node built for good.
 
@@ -63,17 +63,19 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | podSecurityContext.runAsGroup | int | `0` |  |
 | podSecurityContext.runAsUser | int | `1001` |  |
 | podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| ports[0].name | string | `"http2"` |  |
-| ports[0].port | int | `80` |  |
+| ports[0].name | string | `"https"` |  |
+| ports[0].port | int | `443` |  |
 | ports[0].targetPort | int | `9084` |  |
-| ports[1].name | string | `"https"` |  |
-| ports[1].port | int | `443` |  |
+| ports[1].name | string | `"grpc"` |  |
+| ports[1].port | int | `9084` |  |
 | ports[1].targetPort | int | `9084` |  |
-| ports[2].name | string | `"grpc"` |  |
-| ports[2].port | int | `9084` |  |
-| ports[2].targetPort | int | `9084` |  |
+| probes.livenessProbe.grpc.port | int | `9084` |  |
+| probes.livenessProbe.initialDelaySeconds | int | `30` |  |
+| probes.readinessProbe.grpc.port | int | `9084` |  |
+| probes.readinessProbe.timeoutSeconds | int | `20` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | float | `2` |  |
+| resources.limits.ephemeral-storage | string | `"500Mi"` |  |
 | resources.limits.memory | string | `"2000Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"2000Mi"` |  |
@@ -81,6 +83,7 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | service | string | `"bifrost-node"` |  |
+| serviceAccount.automountToken | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `"bifrost-node"` |  |
 | serviceType | string | `"ClusterIP"` |  |

--- a/charts/bifrost/templates/deployment.yaml
+++ b/charts/bifrost/templates/deployment.yaml
@@ -66,10 +66,14 @@ spec:
               mountPath: {{ .Values.configMap.mountPath | quote }}
             - name: {{ (print .Values.service "-pv") | quote }}
               mountPath: {{ .Values.volume.mountDirectory }}
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: {{ (print .Values.service "-config") | quote }}
           configMap:
             name: {{ .Values.service | lower | quote }}
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: {{ (print .Values.service "-pv") | quote }}

--- a/charts/bifrost/templates/serviceAccount.yaml
+++ b/charts/bifrost/templates/serviceAccount.yaml
@@ -7,4 +7,5 @@ metadata:
     app.kubernetes.io/name: {{ .Values.serviceAccount.name | lower | quote }}
     app.kubernetes.io/part-of: {{ .Values.system | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
 {{- end }}

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -24,6 +24,7 @@ args: ["--dataDir", "/mnt/bifrost/data", "--stakingDir", "/mnt/bifrost/staking"]
 serviceAccount:
   name: bifrost-node
   create: true
+  automountToken: false
 
 # The initial number of pod replicas to run for your service
 replicaCount: 1
@@ -42,9 +43,6 @@ serviceType: ClusterIP
 # Ports must be named <protocol>[-<suffix>] to work with Istio.
 # Valid protocols are grpc, http, http2, https, mongo, mysql, redis, tcp, tls, udp
 ports:
-  - name: http2
-    port: 80
-    targetPort: 9084
   - name: https
     port: 443
     targetPort: 9084
@@ -122,6 +120,7 @@ resources:
   limits:
     memory: "2000Mi"
     cpu: 2.0
+    ephemeral-storage: "500Mi"
 
 podSecurityContext:
   runAsUser: 1001 # TODO: Update Bifrost Docker container to use high UID. Add CKV_K8S_40 as a check.
@@ -142,17 +141,15 @@ networkPolicy:
 
 # Probe settings (use Kubernetes syntax)
 # Optional
-# probes:
-#   livenessProbe:
-#     initialDelaySeconds: 30
-#     httpGet:
-#       path: /status
-#       port: 9585
-#   readinessProbe:
-#     timeoutSeconds: 10
-#     httpGet:
-#       path: /status
-#       port: 9585
+probes:
+  livenessProbe:
+    initialDelaySeconds: 30
+    grpc:
+      port: 9084
+  readinessProbe:
+    timeoutSeconds: 20
+    grpc:
+      port: 9084
 
 configMap: # Optional
   # Where the config map should be mounted inside your container's filesystem.

--- a/charts/faucet/README.md
+++ b/charts/faucet/README.md
@@ -8,9 +8,12 @@ A Helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| autoscaling.maxReplicas | int | `5` |  |
+| autoscaling.maxReplicas | int | `1` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetAverageCpuUtilization | int | `80` |  |
+| configMap.content | string | `"worker_processes  auto;\nerror_log  /tmp/nginx/error.log warn;\npid        /tmp/nginx/nginx.pid;\nevents {\n    worker_connections  1024;\n}\nhttp {\n    default_type  application/octet-stream;\n    log_format  main  '$remote_addr - $remote_user [$time_local] \"$request\" '\n                      '$status $body_bytes_sent \"$http_referer\" '\n                      '\"$http_user_agent\" \"$http_x_forwarded_for\"';\n    access_log  /var/log/nginx/access.log  main;\n    sendfile        on;\n    #tcp_nopush     on;\n    keepalive_timeout  65;\n    #gzip  on;\n    include /etc/nginx/conf.d/*.conf;\n    server {\n      listen 9999;\n      location /healthz {\n        access_log          off;\n        return              200;\n      }\n    }\n}\n"` |  |
+| configMap.fileName | string | `"nginx.conf"` |  |
+| configMap.mountPath | string | `"/etc/nginx"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"toplprotocol/faucet"` |  |
 | image.tag | string | `nil` |  |
@@ -20,14 +23,19 @@ A Helm chart for Kubernetes
 | maxUnavailable | int | `1` |  |
 | outlierDetection.consecutive5xxErrors | int | `5` |  |
 | overallTimeout | string | `"10s"` |  |
+| podSecurityContext.fsGroup | int | `101` |  |
+| podSecurityContext.runAsGroup | int | `101` |  |
+| podSecurityContext.runAsUser | int | `101` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| podSecurityContext.supplementalGroups[0] | int | `101` |  |
 | ports[0].name | string | `"https-svc"` |  |
 | ports[0].port | int | `443` |  |
-| ports[0].targetPort | int | `80` |  |
-| probes.livenessProbe.httpGet.path | string | `"/"` |  |
-| probes.livenessProbe.httpGet.port | int | `80` |  |
+| ports[0].targetPort | int | `9999` |  |
+| probes.livenessProbe.httpGet.path | string | `"/healthz"` |  |
+| probes.livenessProbe.httpGet.port | int | `9999` |  |
 | probes.livenessProbe.initialDelaySeconds | int | `30` |  |
-| probes.readinessProbe.httpGet.path | string | `"/"` |  |
-| probes.readinessProbe.httpGet.port | int | `80` |  |
+| probes.readinessProbe.httpGet.path | string | `"/healthz"` |  |
+| probes.readinessProbe.httpGet.port | int | `9999` |  |
 | probes.readinessProbe.timeoutSeconds | int | `10` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"250m"` |  |
@@ -37,6 +45,9 @@ A Helm chart for Kubernetes
 | resources.requests.memory | string | `"32Mi"` |  |
 | retries.attempts | int | `3` |  |
 | retries.perTryTimeout | string | `"2s"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | service | string | `"faucet"` |  |
 | serviceAccount.automountToken | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |


### PR DESCRIPTION
## Purpose
Bit of carry over from a few sprints.

Update Helm Charts to conform to Gatekeeper rules.

## Approach
Update the helm charts we are currently using to conform to the various Gatekeeper rules we have.

## Testing
Deployed to GKE.

Checklist:

* [x] I have bumped the chart version.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`

Changes are automatically published when merged to `main`. They are not published on branches.
