### PR TITLE
Update chart version for faucet

### DIFF
--- a/charts/faucet/Chart.yaml
+++ b/charts/faucet/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: faucet
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/charts/faucet/README.md
+++ b/charts/faucet/README.md
@@ -1,6 +1,6 @@
 # faucet
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
## Purpose
The chart releaser action is failing because forgot to update the chart version for Faucet and was unable to publish the release.

## Approach
Update the Faucet chart version.

In the future, I will add a validation step to prevent this from happening.

## Testing

Checklist:

* [x] I have bumped the chart version.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`

Changes are automatically published when merged to `main`. They are not published on branches.
