### PR TITLE
Bifrost helm fixes

### DIFF
--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-alpha7"
+appVersion: "2.0.0-alpha8"
 
 #TODO: Find a better icon.
 icon: https://uploads-ssl.webflow.com/60f98f46d44e675abb7e66ea/611c4d83ed3df101fd221875_topl_basew.svg

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -1,6 +1,6 @@
 # bifrost
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha7](https://img.shields.io/badge/AppVersion-2.0.0--alpha7-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha8](https://img.shields.io/badge/AppVersion-2.0.0--alpha8-informational?style=flat-square)
 
 A Helm chart for Bifrost, the Topl blockchain node built for good.
 
@@ -20,8 +20,8 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | args[2] | string | `"--stakingDir"` |  |
 | args[3] | string | `"/mnt/bifrost/staking"` |  |
 | command | string | `nil` |  |
-| configMap.content | string | `"bifrost {\n  chainReplicator {\n  enableChainReplicator = false\n  checkMissingBlock = true\n  }\n}\n"` |  |
-| configMap.fileName | string | `"application.conf"` |  |
+| configMap.content | string | `"bifrost:\n  big-bang:\n    type: public\n    genesis-id: b_6D8mXdqjsGrJbnXf6PqfWQrdTfKr3U5nbLGJGyYVgjqs\n    source-path: https://raw.githubusercontent.com/Topl/Genesis_Testnets/main/testnet0/\n"` |  |
+| configMap.fileName | string | `"custom-config.yaml"` |  |
 | configMap.mountPath | string | `"/config/bifrost-config"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"toplprotocol/bifrost-node"` |  |
@@ -63,12 +63,18 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | podSecurityContext.runAsGroup | int | `0` |  |
 | podSecurityContext.runAsUser | int | `1001` |  |
 | podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| ports[0].name | string | `"https"` |  |
-| ports[0].port | int | `443` |  |
+| ports[0].name | string | `"http2"` |  |
+| ports[0].port | int | `80` |  |
 | ports[0].targetPort | int | `9084` |  |
-| ports[1].name | string | `"grpc"` |  |
-| ports[1].port | int | `9084` |  |
+| ports[1].name | string | `"https"` |  |
+| ports[1].port | int | `443` |  |
 | ports[1].targetPort | int | `9084` |  |
+| ports[2].name | string | `"grpc"` |  |
+| ports[2].port | int | `9084` |  |
+| ports[2].targetPort | int | `9084` |  |
+| ports[3].name | string | `"tcp-p2p"` |  |
+| ports[3].port | int | `9085` |  |
+| ports[3].targetPort | int | `9085` |  |
 | probes.livenessProbe.grpc.port | int | `9084` |  |
 | probes.livenessProbe.initialDelaySeconds | int | `30` |  |
 | probes.readinessProbe.grpc.port | int | `9084` |  |

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -162,6 +162,7 @@ configMap: # Optional
   mountPath: /config/bifrost-config
   fileName: custom-config.yaml
   # Everything under content is copied verbatim into your service's configmap.
+  # Example:
   content: |
     bifrost:
       big-bang:

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -43,12 +43,18 @@ serviceType: ClusterIP
 # Ports must be named <protocol>[-<suffix>] to work with Istio.
 # Valid protocols are grpc, http, http2, https, mongo, mysql, redis, tcp, tls, udp
 ports:
+  - name: http2
+    port: 80
+    targetPort: 9084
   - name: https
     port: 443
     targetPort: 9084
   - name: grpc
     port: 9084
     targetPort: 9084
+  - name: tcp-p2p
+    port: 9085
+    targetPort: 9085
 
 p2p:
   ports:
@@ -154,15 +160,15 @@ probes:
 configMap: # Optional
   # Where the config map should be mounted inside your container's filesystem.
   mountPath: /config/bifrost-config
-  fileName: application.conf
+  fileName: custom-config.yaml
   # Everything under content is copied verbatim into your service's configmap.
   content: |
-    bifrost {
-      chainReplicator {
-      enableChainReplicator = false
-      checkMissingBlock = true
-      }
-    }
+    bifrost:
+      big-bang:
+        type: public
+        genesis-id: b_6D8mXdqjsGrJbnXf6PqfWQrdTfKr3U5nbLGJGyYVgjqs
+        source-path: https://raw.githubusercontent.com/Topl/Genesis_Testnets/main/testnet0/
+
 volume:
   mountDirectory: /mnt/bifrost/
   # GKE specific storage classes: standard, standard-rwo, premium-rwo


### PR DESCRIPTION
## Purpose
For whatever reason, removing the `http2` port breaks Istio's traffic routing. Revert it while I figure out why 😵‍💫 

## Approach
* Re-add `http2` port 80 mapping. 
* Update chart to use alpha8 Docker tag
* Add p2p port mapping for public Gateway traffic (so other peers can connect from the host) (Not currently working. Needs some investigation from the p2p side).
* Update configmap to use yaml instead of json.

## Testing
Deployed to GKE.

Checklist:

* [x] I have bumped the chart version.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`

Changes are automatically published when merged to `main`. They are not published on branches.
