### PR TITLE
[Bug]: Explicitly Set Nginx Path for Annulus and Faucet

### DIFF
--- a/charts/annulus/Chart.yaml
+++ b/charts/annulus/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.0
 description: Helm Chart for deploying Annulus, a Topl blockchain explorer.
 name: annulus
 type: application
-version: 0.1.6
+version: 0.1.7

--- a/charts/annulus/README.md
+++ b/charts/annulus/README.md
@@ -1,6 +1,6 @@
 # annulus
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0](https://img.shields.io/badge/AppVersion-v1.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0](https://img.shields.io/badge/AppVersion-v1.0-informational?style=flat-square)
 
 Helm Chart for deploying Annulus, a Topl blockchain explorer.
 
@@ -11,7 +11,7 @@ Helm Chart for deploying Annulus, a Topl blockchain explorer.
 | autoscaling.maxReplicas | int | `5` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetAverageCpuUtilization | int | `80` |  |
-| configMap.content | string | `"worker_processes  auto;\n\nerror_log  /tmp/nginx/error.log warn;\npid        /tmp/nginx/nginx.pid;\n\nevents {\n    worker_connections  1024;\n}\n\nhttp {\n    default_type  application/octet-stream;\n\n    log_format  main  '$remote_addr - $remote_user [$time_local] \"$request\" '\n                      '$status $body_bytes_sent \"$http_referer\" '\n                      '\"$http_user_agent\" \"$http_x_forwarded_for\"';\n\n    access_log  /var/log/nginx/access.log  main;\n\n    sendfile        on;\n    #tcp_nopush     on;\n\n    keepalive_timeout  65;\n\n    #gzip  on;\n\n    include /etc/nginx/conf.d/*.conf;\n\n    server {\n      listen 9999;\n      location /healthz {\n        access_log          off;\n        return              200;\n      }\n    }\n}\n"` |  |
+| configMap.content | string | `"worker_processes  auto;\nerror_log  /tmp/nginx/error.log warn;\npid        /tmp/nginx/nginx.pid;\nevents {\n    worker_connections  1024;\n}\nhttp {\n    default_type  application/octet-stream;\n    log_format  main  '$remote_addr - $remote_user [$time_local] \"$request\" '\n                      '$status $body_bytes_sent \"$http_referer\" '\n                      '\"$http_user_agent\" \"$http_x_forwarded_for\"';\n    access_log  /var/log/nginx/access.log  main;\n    sendfile        on;\n    #tcp_nopush     on;\n    keepalive_timeout  65;\n    #gzip  on;\n    include /etc/nginx/conf.d/*.conf;\n    server {\n      listen 9999;\n      root /usr/share/nginx/html;\n      location /healthz {\n        access_log          off;\n        return              200;\n      }\n    }\n}\n"` |  |
 | configMap.fileName | string | `"nginx.conf"` |  |
 | configMap.mountPath | string | `"/etc/nginx"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -115,34 +115,25 @@ configMap: # Optional
   # Everything under content is copied verbatim into your service's configmap.
   content: |
     worker_processes  auto;
-
     error_log  /tmp/nginx/error.log warn;
     pid        /tmp/nginx/nginx.pid;
-
     events {
         worker_connections  1024;
     }
-
     http {
         default_type  application/octet-stream;
-
         log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '
                           '"$http_user_agent" "$http_x_forwarded_for"';
-
         access_log  /var/log/nginx/access.log  main;
-
         sendfile        on;
         #tcp_nopush     on;
-
         keepalive_timeout  65;
-
         #gzip  on;
-
         include /etc/nginx/conf.d/*.conf;
-
         server {
           listen 9999;
+          root /usr/share/nginx/html;
           location /healthz {
             access_log          off;
             return              200;

--- a/charts/faucet/Chart.yaml
+++ b/charts/faucet/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: faucet
 type: application
-version: 0.1.1
+version: 0.1.2

--- a/charts/faucet/README.md
+++ b/charts/faucet/README.md
@@ -1,6 +1,6 @@
 # faucet
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -11,7 +11,7 @@ A Helm chart for Kubernetes
 | autoscaling.maxReplicas | int | `1` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetAverageCpuUtilization | int | `80` |  |
-| configMap.content | string | `"worker_processes  auto;\nerror_log  /tmp/nginx/error.log warn;\npid        /tmp/nginx/nginx.pid;\nevents {\n    worker_connections  1024;\n}\nhttp {\n    default_type  application/octet-stream;\n    log_format  main  '$remote_addr - $remote_user [$time_local] \"$request\" '\n                      '$status $body_bytes_sent \"$http_referer\" '\n                      '\"$http_user_agent\" \"$http_x_forwarded_for\"';\n    access_log  /var/log/nginx/access.log  main;\n    sendfile        on;\n    #tcp_nopush     on;\n    keepalive_timeout  65;\n    #gzip  on;\n    include /etc/nginx/conf.d/*.conf;\n    server {\n      listen 9999;\n      location /healthz {\n        access_log          off;\n        return              200;\n      }\n    }\n}\n"` |  |
+| configMap.content | string | `"worker_processes  auto;\nerror_log  /tmp/nginx/error.log warn;\npid        /tmp/nginx/nginx.pid;\nevents {\n    worker_connections  1024;\n}\nhttp {\n    default_type  application/octet-stream;\n    log_format  main  '$remote_addr - $remote_user [$time_local] \"$request\" '\n                      '$status $body_bytes_sent \"$http_referer\" '\n                      '\"$http_user_agent\" \"$http_x_forwarded_for\"';\n    access_log  /var/log/nginx/access.log  main;\n    sendfile        on;\n    #tcp_nopush     on;\n    keepalive_timeout  65;\n    #gzip  on;\n    include /etc/nginx/conf.d/*.conf;\n    server {\n      listen 9999;\n      root /usr/share/nginx/html;\n      location /healthz {\n        access_log          off;\n        return              200;\n      }\n    }\n}\n"` |  |
 | configMap.fileName | string | `"nginx.conf"` |  |
 | configMap.mountPath | string | `"/etc/nginx"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/faucet/values.yaml
+++ b/charts/faucet/values.yaml
@@ -131,6 +131,7 @@ configMap: # Optional
         include /etc/nginx/conf.d/*.conf;
         server {
           listen 9999;
+          root /usr/share/nginx/html;
           location /healthz {
             access_log          off;
             return              200;


### PR DESCRIPTION
## Purpose
Currently the Annulus and Faucet helm charts fail to display anything once deployed because the root directory that html files are served from is incorrect.

This can be alleviated by manually editing the configmap contents to correctly set the root, but we should include this by default.

## Approach
* Update default configmap contents to set `root /usr/share/nginx/html;`

## Testing
Deployed and validated that Annulus and Faucet dev instances correctly served traffic.

Checklist:

* [x] I have bumped the chart version.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`

Changes are automatically published when merged to `main`. They are not published on branches.
