### PR TITLE
[BN-1245]: Support External Traffic via P2P for Single Replica Deployments

### DIFF
--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.11
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-alpha8"
+appVersion: "2.0.0-alpha9"
 
 #TODO: Find a better icon.
 icon: https://uploads-ssl.webflow.com/60f98f46d44e675abb7e66ea/611c4d83ed3df101fd221875_topl_basew.svg

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -1,6 +1,6 @@
 # bifrost
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha8](https://img.shields.io/badge/AppVersion-2.0.0--alpha8-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha8](https://img.shields.io/badge/AppVersion-2.0.0--alpha8-informational?style=flat-square)
 
 A Helm chart for Bifrost, the Topl blockchain node built for good.
 
@@ -26,6 +26,7 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"toplprotocol/bifrost-node"` |  |
 | image.tag | string | `""` |  |
+| istio.annotations | object | `{}` |  |
 | istio.corsPolicy.allowCredentials | bool | `true` |  |
 | istio.corsPolicy.allowHeaders[0] | string | `"grpc-timeout"` |  |
 | istio.corsPolicy.allowHeaders[10] | string | `"x-grpc-web"` |  |

--- a/charts/bifrost/templates/deployment.yaml
+++ b/charts/bifrost/templates/deployment.yaml
@@ -42,11 +42,11 @@ spec:
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
           command:
           {{- range .Values.command }}
-            - {{ . }}
+            - {{ quote . }}
           {{- end }}
           args:
           {{- range .Values.args }}
-            - {{ . }}
+            - {{ quote . }}
           {{- end }}
           ports:
 {{- range .Values.ports }}

--- a/charts/bifrost/templates/destinationRule.yaml
+++ b/charts/bifrost/templates/destinationRule.yaml
@@ -15,8 +15,43 @@ spec:
     outlierDetection:
 {{ toYaml .Values.istio.outlierDetection | indent 6 }}
 {{- end }}
-  subsets:
-    - name: {{ (print "v" .Values.version) | quote }}
-      labels:
-        version: {{ .Values.version | quote }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: {{ print .Values.service "-p2p" | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  host: {{ (print .Values.service "-p2p." .Release.Namespace ".svc.cluster.local")  | quote }}
+{{- if .Values.istio.outlierDetection }}
+  trafficPolicy:
+    outlierDetection:
+{{ toYaml .Values.istio.outlierDetection | indent 6 }}
+{{- end }}
+---
+{{- range $index := until (int .Values.replicaCount ) }}
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: {{ (print $.Values.service $index) | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ $.Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ $.Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+spec:
+  host: {{ (print $.Values.service "-" $index "." $.Values.service "-p2p." $.Release.Namespace ".svc.cluster.local")  | quote }}
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+{{- if $.Values.istio.outlierDetection }}
+    outlierDetection:
+{{ toYaml $.Values.istio.outlierDetection | indent 6 }}
+{{- end }}
+---
+{{- end}}
 {{- end}}

--- a/charts/bifrost/templates/envoyFilter.yaml
+++ b/charts/bifrost/templates/envoyFilter.yaml
@@ -18,9 +18,9 @@ spec:
         listener:
           filterChain:
             filter:
-              name: "envoy.http_connection_manager"
+              name: "envoy.filters.network.http_connection_manager"
               subFilter:
-                name: "envoy.router"
+                name: "envoy.filters.http.router"
       patch:
         operation: INSERT_BEFORE
         value:

--- a/charts/bifrost/templates/service.yaml
+++ b/charts/bifrost/templates/service.yaml
@@ -23,6 +23,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ (print .Values.service "-p2p") | quote }}
+  {{- with (mergeOverwrite .Values.istio.annotations) }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.service | lower | quote }}
     app.kubernetes.io/part-of: {{ .Values.system | quote }}

--- a/charts/bifrost/templates/service.yaml
+++ b/charts/bifrost/templates/service.yaml
@@ -29,6 +29,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  type: ClusterIP
   clusterIP: None
   ports:
 {{- range .Values.p2p.ports }}
@@ -37,3 +38,5 @@ spec:
       targetPort: {{ .targetPort }}
       protocol: TCP
 {{- end }}
+  selector:
+    app: {{ .Values.service | lower | quote }}

--- a/charts/bifrost/templates/serviceEntry.yaml
+++ b/charts/bifrost/templates/serviceEntry.yaml
@@ -1,0 +1,32 @@
+# Currently, there is an issue with Istio routing for headless services which prevent this part from being useful. 
+# https://github.com/istio/istio/issues/9784
+# The idea here was to create a ServiceEntry for each of the replicas in the StatefulSet so we can serve TCP p2p traffic to each one individually. 
+# Because of the issue above, a port gets bound cluster wide at 0.0.0.0:9085, which prevents multiple node deployments from happening on the same cluster.
+# I'm leaving this commented out for now in the opes that we may switch our p2p protocol to gRPC, or if a suitable workaround/fix is found.
+
+# {{- if .Values.istio.enabled }}
+# {{- range $index := until (int .Values.replicaCount ) }}
+# apiVersion: networking.istio.io/v1alpha3
+# kind: ServiceEntry
+# metadata:
+#   name: {{ ( print $.Values.service "-" $index ) | lower | quote }}
+#   labels:
+#     app.kubernetes.io/name: {{ $.Values.service | lower | quote }}
+#     app.kubernetes.io/part-of: {{ $.Values.system | quote }}
+#     app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+#   namespace: {{ $.Release.Namespace | quote }}
+# spec:
+#   hosts:
+#   - {{ (print $.Values.service "-" $index "." $.Values.service "-p2p." $.Release.Namespace ".svc.cluster.local")  | quote }}
+#   location: MESH_INTERNAL
+#   resolution: STATIC
+#   ports:
+# {{- range $.Values.p2p.ports }}
+#     - name: {{ .name | quote }}
+#       number: {{ .port }}
+#       targetPort: {{ .targetPort }}
+#       protocol: TCP
+# ---
+# {{- end }}
+# {{- end }}
+# {{- end }}

--- a/charts/bifrost/templates/virtualService.yaml
+++ b/charts/bifrost/templates/virtualService.yaml
@@ -24,11 +24,43 @@ spec:
       route:
       - destination:
           host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
-          subset: {{ (print "v" $.Values.version) | quote }}
           port:
             number: {{ .port }}
       corsPolicy:
 {{- toYaml $.Values.istio.corsPolicy | nindent 8 }}
+{{- if $.Values.istio.retries }}
+      retries:
+{{ toYaml $.Values.istio.retries | indent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" $.Values.istio.overallTimeout}}
+{{- else if $.Values.istio.overallTimeout }}
+      timeout: {{ $.Values.istio.overallTimeout }}
+{{- end }}
+{{- end }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ (print .Values.service "-p2p") | lower | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.service | lower | quote }}
+    app.kubernetes.io/part-of: {{ .Values.system | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  gateways:
+    - {{ .Values.istio.ingressGateway.name | quote }} 
+  hosts:
+    - {{ .Values.istio.ingressGateway.host | quote }}
+  tcp:
+{{- range .Values.p2p.ports }}
+    - match:
+      - port: {{ .port }}
+      route:
+      - destination:
+          # host: {{ (print $.Values.service "-0" "." $.Values.service "-p2p." $.Release.Namespace ".svc.cluster.local")  | quote }} # TODO: Improve routing for multiple statefulsets.
+          host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
+          port:
+            number: {{ .port }}
 {{- if $.Values.istio.retries }}
       retries:
 {{ toYaml $.Values.istio.retries | indent 8 }}

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -68,6 +68,10 @@ p2p:
 istio:
   enabled: true
 
+  annotations:
+    {}
+    # networking.istio.io/exportTo: .
+
   ingressGateway:
     name: istio-gateways/bifrost-gateway
     host: tetra.testnet.torus.topl.tech


### PR DESCRIPTION
## Purpose
There was an issue with routing p2p traffic for our testnets based on our Bifrost Helm Chart.

Essentially we required a few things:
* An internal route for a service that maps to a StatefulSet.
* An external route using Istio that routes TCP traffic on the exposed p2p port into the internal service.

Initially, I wanted to set this up leveraging the headless service and control the replica count to scale the testnet, but this causes issues because for headless TCP services, Istio creates a route at 0.0.0.0:port that is cluster wide and will cause conflicts if anyone else tries to use that same port (including a second deployment of Bifrost).

Instead, the way to support testnets is to just scale horizontally using Helm deployments. This is a bit inefficient, but will do for now.

## Approach
This PR contains the following main changes:
* Add TCP `VirtualService` and update `DestinationRule` for configured p2p port.
* Fix issue passing non-string values to `.Values.args` or `.Values.command` array by using `quote`.
* Update Envoy gRPC web filter to use non-deprecated `filter`s (found this issue while debugging).
* Add ability to pass `Annotations` for Istio specific workloads in the future (once TCP Headless Services work better in Istio/Envoy).

## Testing
* Deployed to `testnet.topl.tech`.
* Validated I could connect from my local machine as a peer.

Checklist:

* [x] I have bumped the chart version.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`

Changes are automatically published when merged to `main`. They are not published on branches.
