### PR TITLE
Update node version, add node selector, update health probe default s…

### DIFF
--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-alpha9"
+appVersion: "2.0.0-alpha10"
 
 #TODO: Find a better icon.
 icon: https://uploads-ssl.webflow.com/60f98f46d44e675abb7e66ea/611c4d83ed3df101fd221875_topl_basew.svg

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -77,11 +77,15 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | ports[3].name | string | `"tcp-p2p"` |  |
 | ports[3].port | int | `9085` |  |
 | ports[3].targetPort | int | `9085` |  |
+| probes.livenessProbe.failureThreshold | int | `3` |  |
 | probes.livenessProbe.grpc.port | int | `9084` |  |
 | probes.livenessProbe.initialDelaySeconds | int | `30` |  |
-| probes.livenessProbe.timeoutSeconds | int | `60` |  |
+| probes.livenessProbe.terminationGracePeriodSeconds | int | `60` |  |
+| probes.livenessProbe.timeoutSeconds | int | `20` |  |
+| probes.readinessProbe.failureThreshold | int | `3` |  |
 | probes.readinessProbe.grpc.port | int | `9084` |  |
-| probes.readinessProbe.timeoutSeconds | int | `60` |  |
+| probes.readinessProbe.terminationGracePeriodSeconds | int | `60` |  |
+| probes.readinessProbe.timeoutSeconds | int | `20` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | float | `2` |  |
 | resources.limits.ephemeral-storage | string | `"500Mi"` |  |

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -78,8 +78,10 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | ports[3].port | int | `9085` |  |
 | ports[3].targetPort | int | `9085` |  |
 | probes.readinessProbe.grpc.port | int | `9084` |  |
-| probes.readinessProbe.terminationGracePeriodSeconds | int | `60` |  |
 | probes.readinessProbe.timeoutSeconds | int | `20` |  |
+| probes.startupProbe.failureThreshold | int | `30` |  |
+| probes.startupProbe.grpc.port | int | `9084` |  |
+| probes.startupProbe.timeoutSeconds | int | `20` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | float | `2` |  |
 | resources.limits.ephemeral-storage | string | `"500Mi"` |  |

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -77,12 +77,6 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | ports[3].name | string | `"tcp-p2p"` |  |
 | ports[3].port | int | `9085` |  |
 | ports[3].targetPort | int | `9085` |  |
-| probes.livenessProbe.failureThreshold | int | `3` |  |
-| probes.livenessProbe.grpc.port | int | `9084` |  |
-| probes.livenessProbe.initialDelaySeconds | int | `30` |  |
-| probes.livenessProbe.terminationGracePeriodSeconds | int | `60` |  |
-| probes.livenessProbe.timeoutSeconds | int | `20` |  |
-| probes.readinessProbe.failureThreshold | int | `3` |  |
 | probes.readinessProbe.grpc.port | int | `9084` |  |
 | probes.readinessProbe.terminationGracePeriodSeconds | int | `60` |  |
 | probes.readinessProbe.timeoutSeconds | int | `20` |  |

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -1,6 +1,6 @@
 # bifrost
 
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha8](https://img.shields.io/badge/AppVersion-2.0.0--alpha8-informational?style=flat-square)
+![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha10](https://img.shields.io/badge/AppVersion-2.0.0--alpha10-informational?style=flat-square)
 
 A Helm chart for Bifrost, the Topl blockchain node built for good.
 
@@ -16,9 +16,9 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | args[0] | string | `"--dataDir"` |  |
-| args[1] | string | `"/mnt/bifrost/data"` |  |
+| args[1] | string | `"/bifrost/data"` |  |
 | args[2] | string | `"--stakingDir"` |  |
-| args[3] | string | `"/mnt/bifrost/staking"` |  |
+| args[3] | string | `"/bifrost/staking"` |  |
 | command | string | `nil` |  |
 | configMap.content | string | `"bifrost:\n  big-bang:\n    type: public\n    genesis-id: b_6D8mXdqjsGrJbnXf6PqfWQrdTfKr3U5nbLGJGyYVgjqs\n    source-path: https://raw.githubusercontent.com/Topl/Genesis_Testnets/main/testnet0/\n"` |  |
 | configMap.fileName | string | `"custom-config.yaml"` |  |
@@ -57,6 +57,7 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | istio.retries | object | `{}` |  |
 | maxUnavailable | int | `1` |  |
 | networkPolicy.enabled | bool | `true` |  |
+| nodeSelector | list | `[]` |  |
 | p2p.ports[0].name | string | `"tcp-p2p"` |  |
 | p2p.ports[0].port | int | `9085` |  |
 | p2p.ports[0].targetPort | int | `9085` |  |
@@ -78,8 +79,9 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | ports[3].targetPort | int | `9085` |  |
 | probes.livenessProbe.grpc.port | int | `9084` |  |
 | probes.livenessProbe.initialDelaySeconds | int | `30` |  |
+| probes.livenessProbe.timeoutSeconds | int | `60` |  |
 | probes.readinessProbe.grpc.port | int | `9084` |  |
-| probes.readinessProbe.timeoutSeconds | int | `20` |  |
+| probes.readinessProbe.timeoutSeconds | int | `60` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | float | `2` |  |
 | resources.limits.ephemeral-storage | string | `"500Mi"` |  |

--- a/charts/bifrost/templates/deployment.yaml
+++ b/charts/bifrost/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- end }}
     spec:
+      nodeSelector: 
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
       serviceAccountName: {{ .Values.serviceAccount.name | lower | quote }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -17,8 +17,11 @@ image:
   imagePullPolicy: IfNotPresent
 
 command: # Optional
-args: ["--dataDir", "/mnt/bifrost/data", "--stakingDir", "/mnt/bifrost/staking"]
+args: ["--dataDir", "/bifrost/data", "--stakingDir", "/bifrost/staking"]
 
+nodeSelector:
+  []
+  # node_pool: guaranteed-pool
 # Istio uses the service account name as a component of the service's security
 # identity. Set "create" to false to use an previously created service account.
 serviceAccount:
@@ -154,10 +157,11 @@ networkPolicy:
 probes:
   livenessProbe:
     initialDelaySeconds: 30
+    timeoutSeconds: 60
     grpc:
       port: 9084
   readinessProbe:
-    timeoutSeconds: 20
+    timeoutSeconds: 60
     grpc:
       port: 9084
 

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -155,17 +155,21 @@ networkPolicy:
 # Probe settings (use Kubernetes syntax)
 # Optional
 probes:
+  startupProbe: # Wait failureThreshold * periodSeconds (300s) before allowing other probes to start.
+    grpc:
+      port: 9084
+    failureThreshold: 30
+    timeoutSeconds: 20
+  readinessProbe:
+    timeoutSeconds: 20
+    grpc:
+      port: 9084
   # livenessProbe:
   #   initialDelaySeconds: 30
   #   terminationGracePeriodSeconds: 60
   #   timeoutSeconds: 20
   #   grpc:
   #     port: 9084
-  readinessProbe:
-    terminationGracePeriodSeconds: 60
-    timeoutSeconds: 20
-    grpc:
-      port: 9084
 
 configMap: # Optional
   # Where the config map should be mounted inside your container's filesystem.

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -155,15 +155,13 @@ networkPolicy:
 # Probe settings (use Kubernetes syntax)
 # Optional
 probes:
-  livenessProbe:
-    initialDelaySeconds: 30
-    failureThreshold: 3
-    terminationGracePeriodSeconds: 60
-    timeoutSeconds: 20
-    grpc:
-      port: 9084
+  # livenessProbe:
+  #   initialDelaySeconds: 30
+  #   terminationGracePeriodSeconds: 60
+  #   timeoutSeconds: 20
+  #   grpc:
+  #     port: 9084
   readinessProbe:
-    failureThreshold: 3
     terminationGracePeriodSeconds: 60
     timeoutSeconds: 20
     grpc:

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -157,11 +157,15 @@ networkPolicy:
 probes:
   livenessProbe:
     initialDelaySeconds: 30
-    timeoutSeconds: 60
+    failureThreshold: 3
+    terminationGracePeriodSeconds: 60
+    timeoutSeconds: 20
     grpc:
       port: 9084
   readinessProbe:
-    timeoutSeconds: 60
+    failureThreshold: 3
+    terminationGracePeriodSeconds: 60
+    timeoutSeconds: 20
     grpc:
       port: 9084
 


### PR DESCRIPTION
## Purpose
Currently we have 2 types of node pools.
* Preemtible
* Guaranteed

The preemtible pool saves some money for us at the cost of sharing the lease with others, which means we can randomly lose the node pool (which is okay for ephemeral deployments).

For Bifrost, we always want a guaranteed pool. 

Also include some misc changes.

## Approach
* Add a `nodeSelector` to the `Deployment` spec.
* Remove the `livenessProbe` for now, since this will result in restarting the node and there are very few cases where we actually want to do this.
* Add `startupProbe` to reduce false positives of probes failing (especially when Genus is enabled).

https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes

## Testing

Checklist:

* [x] I have bumped the chart version.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`

Changes are automatically published when merged to `main`. They are not published on branches.
