### PR TITLE
Support passing env variables to Bifrost

### DIFF
--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -1,6 +1,6 @@
 # bifrost
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha10](https://img.shields.io/badge/AppVersion-2.0.0--alpha10-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-alpha10](https://img.shields.io/badge/AppVersion-2.0.0--alpha10-informational?style=flat-square)
 
 A Helm chart for Bifrost, the Topl blockchain node built for good.
 
@@ -23,6 +23,8 @@ A Helm chart for Bifrost, the Topl blockchain node built for good.
 | configMap.content | string | `"bifrost:\n  big-bang:\n    type: public\n    genesis-id: b_6D8mXdqjsGrJbnXf6PqfWQrdTfKr3U5nbLGJGyYVgjqs\n    source-path: https://raw.githubusercontent.com/Topl/Genesis_Testnets/main/testnet0/\n"` |  |
 | configMap.fileName | string | `"custom-config.yaml"` |  |
 | configMap.mountPath | string | `"/config/bifrost-config"` |  |
+| env[0].name | string | `"JAVA_OPTS"` |  |
+| env[0].value | string | `"-XX:MaxRAMPercentage=70.0"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"toplprotocol/bifrost-node"` |  |
 | image.tag | string | `""` |  |

--- a/charts/bifrost/templates/deployment.yaml
+++ b/charts/bifrost/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
+{{- if .Values.env }}
+          env: {{- toYaml .Values.env | nindent 10 }}
+{{- end }}
           command:
           {{- range .Values.command }}
             - {{ quote . }}

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -19,6 +19,10 @@ image:
 command: # Optional
 args: ["--dataDir", "/bifrost/data", "--stakingDir", "/bifrost/staking"]
 
+env:
+  - name: JAVA_OPTS
+    value: "-XX:MaxRAMPercentage=70.0"
+
 nodeSelector:
   []
   # node_pool: guaranteed-pool


### PR DESCRIPTION
## Purpose
There are a few helpful environment variables we can pass to the Bifrost app, mainly `JVM_OPTS`. 

## Approach
* Add a `env` section in the values.yaml file, which allow us to pass multiple env variables to the container.

I'm also setting `JAVA_OPTS="-XX:MaxRAMPercentage=70.0"` as a default so that the Helm deployments will attempt to use 70% of the configured memory limit.

## Testing
* Manually edited the Bifrost deployment and confirmed this option takes effect.
* `helm temlate --debug ./charts/bifrost`
* Confirmed that setting 1 or multiple values works.

Checklist:

* [x] I have bumped the chart version.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`

Changes are automatically published when merged to `main`. They are not published on branches.
