### PR TITLE
Fix indentation of Genus helm chart

### DIFF
--- a/charts/genus/Chart.yaml
+++ b/charts/genus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/genus/README.md
+++ b/charts/genus/README.md
@@ -1,6 +1,6 @@
 # genus
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-beta2](https://img.shields.io/badge/AppVersion-2.0.0--beta2-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-beta2](https://img.shields.io/badge/AppVersion-2.0.0--beta2-informational?style=flat-square)
 
 A Helm chart for Genus, the data indexer for Bifrost
 

--- a/charts/genus/templates/deployment.yaml
+++ b/charts/genus/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
                 secretKeyRef:
                   name: {{ ((print .Values.service "-db-password") | lower | quote) }}
                   key: db-password
-           {{- toYaml .Values.env | nindent 10 }}
+            {{- toYaml .Values.env | nindent 12 }}
           args:
             - "--orientDbPassword"
             - "$(ORIENT_DB_PASSWORD)"


### PR DESCRIPTION
## Purpose
Small fix for indentation of env vars for Genus.

## Approach
* Update `nindent` value. 

## Testing
* `helm template --debug ./charts/genus` produces correct output.

Checklist:

* [x] I have bumped the chart version for chart changes.
* [x] I have validated the chart with `helm template --debug ./charts/<chart>`.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`.

Changes are automatically published when merged to `main`. They are not published on branches.
