### PR TITLE
Fix OrientDB password regeneration.  Fix deployment data path argument

### DIFF
--- a/charts/genus/Chart.yaml
+++ b/charts/genus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/genus/README.md
+++ b/charts/genus/README.md
@@ -1,6 +1,6 @@
 # genus
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-beta2](https://img.shields.io/badge/AppVersion-2.0.0--beta2-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-beta2](https://img.shields.io/badge/AppVersion-2.0.0--beta2-informational?style=flat-square)
 
 A Helm chart for Genus, the data indexer for Bifrost
 

--- a/charts/genus/templates/dbPassword.yaml
+++ b/charts/genus/templates/dbPassword.yaml
@@ -9,7 +9,7 @@ metadata:
 type: Opaque
 data:
   # retrieve the secret data using lookup function and when not exists, return an empty dictionary / map as result
-  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace ((print .Values.service "-db-password") | lower | quote)) | default dict }}
+  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace ((print .Values.service "-db-password") | lower)) | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   # set $secret to existing secret data or generate a random one when not exists
   {{- $secret := (get $secretData "db-password") | default (randAlphaNum 32 | b64enc) }}

--- a/charts/genus/templates/deployment.yaml
+++ b/charts/genus/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - "--orientDbPassword"
             - "$(ORIENT_DB_PASSWORD)"
             - "--dataDir"
-            - "/genus"
+            - "/genus/orient-db"
             - "--enableReplicator"
             - "{{ .Values.replicator.enable }}"
             - "--nodeRpcHost"


### PR DESCRIPTION
## Purpose
- OrientDB password was regenerated on each deployment
- Genus OrientDB directory was configured at the root of the PV which won't work because the directory already exists at mount
## Approach
- Fix extra "quote" step when retrieving existing Secret
- Nest OrientDB directory at `/genus/orient-db`
## Testing
N/A
Checklist:

* [X ] I have bumped the chart version for chart changes.
* [- ] I have validated the chart with `helm template --debug ./charts/<chart>`.
* [X ] Any new values are backwards compatible and/or have sensible default.
* [- ] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`.

Changes are automatically published when merged to `main`. They are not published on branches.
