### PR TITLE
Update Genus _JAVA_OPTIONS

### DIFF
--- a/charts/genus/Chart.yaml
+++ b/charts/genus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/genus/README.md
+++ b/charts/genus/README.md
@@ -1,6 +1,6 @@
 # genus
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-beta2](https://img.shields.io/badge/AppVersion-2.0.0--beta2-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-beta2](https://img.shields.io/badge/AppVersion-2.0.0--beta2-informational?style=flat-square)
 
 A Helm chart for Genus, the data indexer for Bifrost
 

--- a/charts/genus/values.yaml
+++ b/charts/genus/values.yaml
@@ -18,7 +18,7 @@ image:
 
 env:
   - name: _JAVA_OPTIONS
-    value: "-Xmx1g -Dstorage.diskCache.bufferSize=2000 -XX:ActiveProcessorCount=4"
+    value: "-Xmx1g -Xms1g -Dstorage.diskCache.bufferSize=2000 -XX:ActiveProcessorCount=4 -XX:+AlwaysPreTouch"
 
 nodeSelector:
   []
@@ -120,7 +120,7 @@ istio:
 resources:
   requests:
     memory: "4000Mi"
-    cpu: "20m"
+    cpu: "250m"
   limits:
     memory: "4000Mi"
     ephemeral-storage: "500Mi"

--- a/charts/genus/values.yaml
+++ b/charts/genus/values.yaml
@@ -18,7 +18,7 @@ image:
 
 env:
   - name: _JAVA_OPTIONS
-    value: "-XX:MaxRAMPercentage=70.0 -XX:ActiveProcessorCount=4 -XX:+UseParallelGC"
+    value: "-Xmx1g -Dstorage.diskCache.bufferSize=2000 -XX:ActiveProcessorCount=4"
 
 nodeSelector:
   []
@@ -120,7 +120,7 @@ istio:
 resources:
   requests:
     memory: "4000Mi"
-    cpu: "250m"
+    cpu: "20m"
   limits:
     memory: "4000Mi"
     ephemeral-storage: "500Mi"


### PR DESCRIPTION
## Purpose
- Memory settings aren't tuned for OrientDB
## Approach
- Update settings to allocate extra memory-map space and reduced heap space
- Also reduce CPU requests
## Testing
- Runs in devnet
Checklist:

* [X ] I have bumped the chart version for chart changes.
* [ ] I have validated the chart with `helm template --debug ./charts/<chart>`.
* [X ] Any new values are backwards compatible and/or have sensible default.
* [X ] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`.

Changes are automatically published when merged to `main`. They are not published on branches.
