### PR TITLE
[BN-1478]: Allow Genus to use Manually Created Secret

### DIFF
--- a/charts/genus/Chart.yaml
+++ b/charts/genus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/genus/README.md
+++ b/charts/genus/README.md
@@ -1,6 +1,6 @@
 # genus
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
 
 A Helm chart for Genus, the data indexer for Bifrost
 
@@ -15,6 +15,7 @@ A Helm chart for Genus, the data indexer for Bifrost
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| database.existingSecret | string | `""` |  |
 | env[0].name | string | `"_JAVA_OPTIONS"` |  |
 | env[0].value | string | `"-Xmx1g -Xms1g -Dstorage.diskCache.bufferSize=2000 -XX:ActiveProcessorCount=4 -XX:+AlwaysPreTouch"` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/genus/templates/_helpers.tpl
+++ b/charts/genus/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the database secret name, or use the one specified
+*/}}
+{{- define "genus.dbSecretName" -}}
+{{- default ((print .Values.service "-db-password") | lower | quote) (.Values.database.existingSecret | lower | quote) }}
+{{- end }}

--- a/charts/genus/templates/dbPassword.yaml
+++ b/charts/genus/templates/dbPassword.yaml
@@ -1,9 +1,10 @@
 # Reference: https://itnext.io/manage-auto-generated-secrets-in-your-helm-charts-5aee48ba6918
 
+{{ if (not .Values.database.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ ((print .Values.service "-db-password") | lower | quote) }}
+  name: {{ template "genus.dbSecretName" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
 type: Opaque
@@ -14,3 +15,4 @@ data:
   # set $secret to existing secret data or generate a random one when not exists
   {{- $secret := (get $secretData "db-password") | default (randAlphaNum 32 | b64enc) }}
   db-password: {{ $secret | quote }}
+{{- end }}

--- a/charts/genus/templates/deployment.yaml
+++ b/charts/genus/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: ORIENT_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ ((print .Values.service "-db-password") | lower | quote) }}
+                  name: {{ template "genus.dbSecretName" . }}
                   key: db-password
             {{- toYaml .Values.env | nindent 12 }}
           args:

--- a/charts/genus/values.yaml
+++ b/charts/genus/values.yaml
@@ -174,3 +174,6 @@ nodeRpc:
 
 replicator:
   enable: true
+
+database:
+  existingSecret: ""


### PR DESCRIPTION
## Purpose
ArgoCD has an issue with the Helm [lookup function](https://github.com/argoproj/argo-cd/issues/5202).

This causes the helm `lookup` function to not work correctly, which leads to Genus recreating the password each time it is deployed (which is bad :frowning_face: ).

## Approach
* Allow Genus to manually specify a `Secret` instead.

To solve the above issue, I'm just going to use a secret manager with ArgoCD to avoid this issue. To enable the behavior, we need to allow Genus to use existing secrets for OrientDB.

## Testing
* `helm template` both with `database.existingSecret` set and unset. Ensured that `Secret` is only templated when this value is unset, and ensured the new secret name is used when overridden.

Checklist:

* [ ] I have bumped the chart version for chart changes.
* [ ] I have validated the chart with `helm template --debug ./charts/<chart>`.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`.

Changes are automatically published when merged to `main`. They are not published on branches.
