### PR TITLE
[BN-1521]: Support 301 redirects for Istio http Routes

### DIFF
--- a/charts/annulus/Chart.yaml
+++ b/charts/annulus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "v1.4.2"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.12
+version: 0.1.13
 
 name: annulus
 description: A Helm chart for Annulus, an Apparatus blockchain explorer.

--- a/charts/annulus/README.md
+++ b/charts/annulus/README.md
@@ -1,6 +1,6 @@
 # annulus
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![AppVersion: v1.4.2](https://img.shields.io/badge/AppVersion-v1.4.2-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![AppVersion: v1.4.2](https://img.shields.io/badge/AppVersion-v1.4.2-informational?style=flat-square)
 
 A Helm chart for Annulus, an Apparatus blockchain explorer.
 
@@ -36,8 +36,9 @@ Kubernetes: `>=1.23.0-0`
 | image.tag | string | `nil` |  |
 | istio.annotations | object | `{}` |  |
 | istio.enabled | bool | `false` |  |
-| istio.ingressGateway.hosts[0] | string | `"annulus.example.com"` |  |
-| istio.ingressGateway.name | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.gateways[0] | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.host | string | `"annulus.example.com"` |  |
+| istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
 | istio.retries | object | `{}` |  |

--- a/charts/annulus/templates/virtualService.yaml
+++ b/charts/annulus/templates/virtualService.yaml
@@ -8,12 +8,39 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   gateways:
-    - {{ .Values.istio.ingressGateway.name | quote }}
-  hosts:
-  {{- range .Values.istio.ingressGateway.hosts }}
+  {{- range .Values.istio.ingress.gateways }}
     - {{ . | quote }}
   {{- end }}
+  hosts:
+    - {{ .Values.istio.ingress.host | quote }}
+  {{- range .Values.istio.ingress.redirectHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
+  # Redirect routes
+  {{- range .Values.istio.virtualServiceRoutes.http }}
+    - match:
+      {{- range $.Values.istio.ingress.redirectHosts }}
+      - uri:
+          exact: {{ . | quote }}
+      {{- end }}
+      redirect:
+        authority: {{ $.Values.istio.ingress.host | quote }}
+      {{- with $.Values.istio.corsPolicy }}
+      corsPolicy:
+      {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- if $.Values.istio.retries }}
+      retries:
+      {{ toYaml $.Values.istio.retries | nindent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" $.Values.istio.overallTimeout}}
+      {{- else if $.Values.istio.overallTimeout }}
+      timeout: {{ $.Values.istio.overallTimeout }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  # Normal routes
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       - port: {{ .port }}
@@ -26,8 +53,10 @@ spec:
           host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
           port:
             number: {{ .targetPort }}
+      {{- with $.Values.istio.corsPolicy }}
       corsPolicy:
-      {{- toYaml $.Values.istio.corsPolicy | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $.Values.istio.retries }}
       retries:
       {{ toYaml $.Values.istio.retries | nindent 8 }}
@@ -36,6 +65,7 @@ spec:
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
   {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.tcp }}
   tcp:
   {{- range .Values.istio.virtualServiceRoutes.tcp }}
     - match:
@@ -52,5 +82,6 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -58,10 +58,12 @@ istio:
     {}
     # networking.istio.io/exportTo: .
 
-  ingressGateway:
-    name: istio-gateways/gateway
-    hosts:
-      - annulus.example.com
+  ingress:
+    gateways:
+    - istio-gateways/gateway
+    host: annulus.example.com
+    # Adds 301 redirects for the provided hosts to the main host.
+    redirectHosts: []
 
   # # The overall timeout for requests to this service
   # # Optional

--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "2.0.0-beta3"
 kubeVersion: ">=1.23.0-0"
-version: 0.2.4
+version: 0.2.5
 
 name: bifrost
 description: A Helm chart for Bifrost, the Apparatus blockchain node built for good.

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -1,6 +1,6 @@
 # bifrost
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
 
 A Helm chart for Bifrost, the Apparatus blockchain node built for good.
 
@@ -63,8 +63,9 @@ Kubernetes: `>=1.23.0-0`
 | istio.corsPolicy.maxAge | string | `"24h"` |  |
 | istio.createGrpcWebFilter | bool | `true` |  |
 | istio.enabled | bool | `false` |  |
-| istio.ingressGateway.hosts[0] | string | `"bifrost.example.com"` |  |
-| istio.ingressGateway.name | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.gateways[0] | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.host | string | `"bifrost.example.com"` |  |
+| istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
 | istio.retries | object | `{}` |  |

--- a/charts/bifrost/templates/virtualService.yaml
+++ b/charts/bifrost/templates/virtualService.yaml
@@ -8,12 +8,39 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   gateways:
-    - {{ .Values.istio.ingressGateway.name | quote }}
-  hosts:
-  {{- range .Values.istio.ingressGateway.hosts }}
+  {{- range .Values.istio.ingress.gateways }}
     - {{ . | quote }}
   {{- end }}
+  hosts:
+    - {{ .Values.istio.ingress.host | quote }}
+  {{- range .Values.istio.ingress.redirectHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
+  # Redirect routes
+  {{- range .Values.istio.virtualServiceRoutes.http }}
+    - match:
+      {{- range $.Values.istio.ingress.redirectHosts }}
+      - uri:
+          exact: {{ . | quote }}
+      {{- end }}
+      redirect:
+        authority: {{ $.Values.istio.ingress.host | quote }}
+      {{- with $.Values.istio.corsPolicy }}
+      corsPolicy:
+      {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- if $.Values.istio.retries }}
+      retries:
+      {{ toYaml $.Values.istio.retries | nindent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" $.Values.istio.overallTimeout}}
+      {{- else if $.Values.istio.overallTimeout }}
+      timeout: {{ $.Values.istio.overallTimeout }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  # Normal routes
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       - port: {{ .port }}
@@ -26,8 +53,10 @@ spec:
           host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
           port:
             number: {{ .targetPort }}
+      {{- with $.Values.istio.corsPolicy }}
       corsPolicy:
-      {{- toYaml $.Values.istio.corsPolicy | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $.Values.istio.retries }}
       retries:
       {{ toYaml $.Values.istio.retries | nindent 8 }}
@@ -36,6 +65,7 @@ spec:
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
   {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.tcp }}
   tcp:
   {{- range .Values.istio.virtualServiceRoutes.tcp }}
     - match:
@@ -52,5 +82,6 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -89,10 +89,11 @@ istio:
     {}
     # networking.istio.io/exportTo: .
 
-  ingressGateway:
-    name: istio-gateways/gateway
-    hosts:
-      - bifrost.example.com
+  ingress:
+    gateways: 
+    - istio-gateways/gateway
+    host: bifrost.example.com
+    redirectHosts: []
 
   corsPolicy:
     allowOrigins:

--- a/charts/bitcoin-node/Chart.yaml
+++ b/charts/bitcoin-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "23"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.2
+version: 0.1.3
 
 name: bitcoin-node
 description: A Helm chart for running a Bitcoin node.

--- a/charts/bitcoin-node/README.md
+++ b/charts/bitcoin-node/README.md
@@ -1,6 +1,6 @@
 # bitcoin-node
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 23](https://img.shields.io/badge/AppVersion-23-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 23](https://img.shields.io/badge/AppVersion-23-informational?style=flat-square)
 
 A Helm chart for running a Bitcoin node.
 
@@ -47,8 +47,9 @@ Kubernetes: `>=1.23.0-0`
 | image.tag | string | `""` |  |
 | istio.annotations | object | `{}` |  |
 | istio.enabled | bool | `false` |  |
-| istio.ingressGateway.hosts[0] | string | `"bitcoin.example.com"` |  |
-| istio.ingressGateway.name | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.gateways[0] | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.host | string | `"bitcoin.example.com"` |  |
+| istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
 | istio.retries | object | `{}` |  |

--- a/charts/bitcoin-node/templates/virtualService.yaml
+++ b/charts/bitcoin-node/templates/virtualService.yaml
@@ -8,12 +8,39 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   gateways:
-    - {{ .Values.istio.ingressGateway.name | quote }}
-  hosts:
-  {{- range .Values.istio.ingressGateway.hosts }}
+  {{- range .Values.istio.ingress.gateways }}
     - {{ . | quote }}
   {{- end }}
+  hosts:
+    - {{ .Values.istio.ingress.host | quote }}
+  {{- range .Values.istio.ingress.redirectHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
+  # Redirect routes
+  {{- range .Values.istio.virtualServiceRoutes.http }}
+    - match:
+      {{- range $.Values.istio.ingress.redirectHosts }}
+      - uri:
+          exact: {{ . | quote }}
+      {{- end }}
+      redirect:
+        authority: {{ $.Values.istio.ingress.host | quote }}
+      {{- with $.Values.istio.corsPolicy }}
+      corsPolicy:
+      {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- if $.Values.istio.retries }}
+      retries:
+      {{ toYaml $.Values.istio.retries | nindent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" $.Values.istio.overallTimeout}}
+      {{- else if $.Values.istio.overallTimeout }}
+      timeout: {{ $.Values.istio.overallTimeout }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  # Normal routes
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       - port: {{ .port }}
@@ -26,8 +53,10 @@ spec:
           host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
           port:
             number: {{ .targetPort }}
+      {{- with $.Values.istio.corsPolicy }}
       corsPolicy:
-      {{- toYaml $.Values.istio.corsPolicy | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $.Values.istio.retries }}
       retries:
       {{ toYaml $.Values.istio.retries | nindent 8 }}
@@ -36,6 +65,7 @@ spec:
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
   {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.tcp }}
   tcp:
   {{- range .Values.istio.virtualServiceRoutes.tcp }}
     - match:
@@ -52,5 +82,6 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/bitcoin-node/values.yaml
+++ b/charts/bitcoin-node/values.yaml
@@ -83,10 +83,11 @@ istio:
     {}
     # networking.istio.io/exportTo: .
 
-  ingressGateway:
-    name: istio-gateways/gateway
-    hosts:
-      - bitcoin.example.com
+  ingress:
+    gateways: 
+    - istio-gateways/gateway
+    host: bitcoin.example.com
+    redirectHosts: []
 
   # # The overall timeout for requests to this service
   # # Optional

--- a/charts/bitcoin.md
+++ b/charts/bitcoin.md
@@ -1,0 +1,5 @@
+1. When bitcoin node restarts, it needs to reload the wallet. 
+    1. `init-container`needs to check if the wallet exists, if not create it. Otherwise, reload the wallet.
+    2. RCP command, probably use `init-container`. 
+2. `CronJob` needs to packaged with the `bitcoin-node` helm deployment.
+

--- a/charts/btc-bridge/Chart.yaml
+++ b/charts/btc-bridge/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "latest"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.3
+version: 0.1.4
 
 name: btc-bridge
 description: Helm Chart for deploying the Apparatus BTC Bridge.

--- a/charts/btc-bridge/README.md
+++ b/charts/btc-bridge/README.md
@@ -1,6 +1,6 @@
 # btc-bridge
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Helm Chart for deploying the Apparatus BTC Bridge.
 
@@ -54,9 +54,10 @@ Kubernetes: `>=1.23.0-0`
 | initWallet.enabled | bool | `false` |  |
 | initWallet.image | string | `"dacr/coursier-launcher:openjdk-11"` |  |
 | istio.enabled | bool | `false` |  |
-| istio.ingressGateway.hosts[0] | string | `"bridge.example.com"` |  |
-| istio.ingressGateway.matchPrefix[0] | string | `"/"` |  |
-| istio.ingressGateway.name | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.gateways[0] | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.host | string | `"bridge.example.com"` |  |
+| istio.ingress.matchPrefix[0] | string | `"/"` |  |
+| istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
 | istio.retries | object | `{}` |  |

--- a/charts/btc-bridge/templates/virtualService.yaml
+++ b/charts/btc-bridge/templates/virtualService.yaml
@@ -8,12 +8,39 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   gateways:
-    - {{ .Values.istio.ingressGateway.name | quote }}
-  hosts:
-  {{- range .Values.istio.ingressGateway.hosts }}
+  {{- range .Values.istio.ingress.gateways }}
     - {{ . | quote }}
   {{- end }}
+  hosts:
+    - {{ .Values.istio.ingress.host | quote }}
+  {{- range .Values.istio.ingress.redirectHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
+  # Redirect routes
+  {{- range .Values.istio.virtualServiceRoutes.http }}
+    - match:
+      {{- range $.Values.istio.ingress.redirectHosts }}
+      - uri:
+          exact: {{ . | quote }}
+      {{- end }}
+      redirect:
+        authority: {{ $.Values.istio.ingress.host | quote }}
+      {{- with $.Values.istio.corsPolicy }}
+      corsPolicy:
+      {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- if $.Values.istio.retries }}
+      retries:
+      {{ toYaml $.Values.istio.retries | nindent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" $.Values.istio.overallTimeout}}
+      {{- else if $.Values.istio.overallTimeout }}
+      timeout: {{ $.Values.istio.overallTimeout }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  # Normal routes
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       - port: {{ .port }}
@@ -26,8 +53,10 @@ spec:
           host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
           port:
             number: {{ .targetPort }}
+      {{- with $.Values.istio.corsPolicy }}
       corsPolicy:
-      {{- toYaml $.Values.istio.corsPolicy | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $.Values.istio.retries }}
       retries:
       {{ toYaml $.Values.istio.retries | nindent 8 }}
@@ -36,6 +65,7 @@ spec:
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
   {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.tcp }}
   tcp:
   {{- range .Values.istio.virtualServiceRoutes.tcp }}
     - match:
@@ -52,5 +82,6 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/btc-bridge/values.yaml
+++ b/charts/btc-bridge/values.yaml
@@ -62,10 +62,11 @@ maxUnavailable: 1
 istio:
   enabled: false
 
-  ingressGateway:
-    name: istio-gateways/gateway
-    hosts:
-      - bridge.example.com
+  ingress:
+    gateways: 
+    - istio-gateways/gateway
+    host: bridge.example.com
+    redirectHosts: []
     matchPrefix:
       - "/"
 

--- a/charts/btc-wallet/Chart.yaml
+++ b/charts/btc-wallet/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "latest"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.3
+version: 0.1.4
 
 name: btc-wallet
 description: Helm Chart for deploying the Apparatus BTC Wallet.

--- a/charts/btc-wallet/README.md
+++ b/charts/btc-wallet/README.md
@@ -1,6 +1,6 @@
 # btc-wallet
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Helm Chart for deploying the Apparatus BTC Wallet.
 
@@ -44,9 +44,10 @@ Kubernetes: `>=1.23.0-0`
 | image.repository | string | `"ghcr.io/topl/demo-btc-wallet"` |  |
 | image.tag | string | `""` |  |
 | istio.enabled | bool | `false` |  |
-| istio.ingressGateway.hosts[0] | string | `"wallet.example.com"` |  |
-| istio.ingressGateway.matchPrefix[0] | string | `"/"` |  |
-| istio.ingressGateway.name | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.gateways[0] | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.host | string | `"wallet.example.com"` |  |
+| istio.ingress.matchPrefix[0] | string | `"/"` |  |
+| istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
 | istio.retries | object | `{}` |  |

--- a/charts/btc-wallet/templates/virtualService.yaml
+++ b/charts/btc-wallet/templates/virtualService.yaml
@@ -8,12 +8,39 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   gateways:
-    - {{ .Values.istio.ingressGateway.name | quote }}
-  hosts:
-  {{- range .Values.istio.ingressGateway.hosts }}
+  {{- range .Values.istio.ingress.gateways }}
     - {{ . | quote }}
   {{- end }}
+  hosts:
+    - {{ .Values.istio.ingress.host | quote }}
+  {{- range .Values.istio.ingress.redirectHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
+  # Redirect routes
+  {{- range .Values.istio.virtualServiceRoutes.http }}
+    - match:
+      {{- range $.Values.istio.ingress.redirectHosts }}
+      - uri:
+          exact: {{ . | quote }}
+      {{- end }}
+      redirect:
+        authority: {{ $.Values.istio.ingress.host | quote }}
+      {{- with $.Values.istio.corsPolicy }}
+      corsPolicy:
+      {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- if $.Values.istio.retries }}
+      retries:
+      {{ toYaml $.Values.istio.retries | nindent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" $.Values.istio.overallTimeout}}
+      {{- else if $.Values.istio.overallTimeout }}
+      timeout: {{ $.Values.istio.overallTimeout }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  # Normal routes
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       - port: {{ .port }}
@@ -26,8 +53,10 @@ spec:
           host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
           port:
             number: {{ .targetPort }}
+      {{- with $.Values.istio.corsPolicy }}
       corsPolicy:
-      {{- toYaml $.Values.istio.corsPolicy | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $.Values.istio.retries }}
       retries:
       {{ toYaml $.Values.istio.retries | nindent 8 }}
@@ -36,6 +65,7 @@ spec:
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
   {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.tcp }}
   tcp:
   {{- range .Values.istio.virtualServiceRoutes.tcp }}
     - match:
@@ -52,5 +82,6 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/btc-wallet/values.yaml
+++ b/charts/btc-wallet/values.yaml
@@ -52,10 +52,11 @@ maxUnavailable: 1
 istio:
   enabled: false
 
-  ingressGateway:
-    name: istio-gateways/gateway
-    hosts:
-      - wallet.example.com
+  ingress:
+    gateways: 
+    - istio-gateways/gateway
+    host: wallet.example.com
+    redirectHosts: []
     matchPrefix:
       - "/"
 

--- a/charts/faucet/Chart.yaml
+++ b/charts/faucet/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "0.1.0"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.5
+version: 0.1.6
 
 name: faucet
 description: Helm Chart for deploying the Apparatus Faucet.

--- a/charts/faucet/README.md
+++ b/charts/faucet/README.md
@@ -1,6 +1,6 @@
 # faucet
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Helm Chart for deploying the Apparatus Faucet.
 
@@ -36,8 +36,9 @@ Kubernetes: `>=1.23.0-0`
 | image.tag | string | `nil` |  |
 | istio.annotations | object | `{}` |  |
 | istio.enabled | bool | `false` |  |
-| istio.ingressGateway.hosts[0] | string | `"faucet.example.com"` |  |
-| istio.ingressGateway.name | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.gateways[0] | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.host | string | `"faucet.example.com"` |  |
+| istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
 | istio.retries | object | `{}` |  |

--- a/charts/faucet/templates/virtualService.yaml
+++ b/charts/faucet/templates/virtualService.yaml
@@ -8,12 +8,39 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   gateways:
-    - {{ .Values.istio.ingressGateway.name | quote }}
-  hosts:
-  {{- range .Values.istio.ingressGateway.hosts }}
+  {{- range .Values.istio.ingress.gateways }}
     - {{ . | quote }}
   {{- end }}
+  hosts:
+    - {{ .Values.istio.ingress.host | quote }}
+  {{- range .Values.istio.ingress.redirectHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
+  # Redirect routes
+  {{- range .Values.istio.virtualServiceRoutes.http }}
+    - match:
+      {{- range $.Values.istio.ingress.redirectHosts }}
+      - uri:
+          exact: {{ . | quote }}
+      {{- end }}
+      redirect:
+        authority: {{ $.Values.istio.ingress.host | quote }}
+      {{- with $.Values.istio.corsPolicy }}
+      corsPolicy:
+      {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- if $.Values.istio.retries }}
+      retries:
+      {{ toYaml $.Values.istio.retries | nindent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" $.Values.istio.overallTimeout}}
+      {{- else if $.Values.istio.overallTimeout }}
+      timeout: {{ $.Values.istio.overallTimeout }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  # Normal routes
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       - port: {{ .port }}
@@ -26,8 +53,10 @@ spec:
           host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
           port:
             number: {{ .targetPort }}
+      {{- with $.Values.istio.corsPolicy }}
       corsPolicy:
-      {{- toYaml $.Values.istio.corsPolicy | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $.Values.istio.retries }}
       retries:
       {{ toYaml $.Values.istio.retries | nindent 8 }}
@@ -36,6 +65,7 @@ spec:
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
   {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.tcp }}
   tcp:
   {{- range .Values.istio.virtualServiceRoutes.tcp }}
     - match:
@@ -52,5 +82,6 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/faucet/values.yaml
+++ b/charts/faucet/values.yaml
@@ -58,10 +58,11 @@ istio:
     {}
     # networking.istio.io/exportTo: .
 
-  ingressGateway:
-    name: istio-gateways/gateway
-    hosts:
-      - faucet.example.com
+  ingress:
+    gateways: 
+    - istio-gateways/gateway
+    host: faucet.example.com
+    redirectHosts: []
 
   # # The overall timeout for requests to this service
   # # Optional

--- a/charts/genus/Chart.yaml
+++ b/charts/genus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "2.0.0-beta3"
 kubeVersion: ">=1.23.0-0"
-version: 0.2.8
+version: 0.2.9
 
 name: genus
 description: Helm Chart for Genus, the data indexer for Apparatus.

--- a/charts/genus/README.md
+++ b/charts/genus/README.md
@@ -1,6 +1,6 @@
 # genus
 
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
+![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
 
 Helm Chart for Genus, the data indexer for Apparatus.
 
@@ -55,8 +55,9 @@ Kubernetes: `>=1.23.0-0`
 | istio.corsPolicy.maxAge | string | `"24h"` |  |
 | istio.createGrpcWebFilter | bool | `true` |  |
 | istio.enabled | bool | `false` |  |
-| istio.ingressGateway.hosts[0] | string | `"genus.testnet.topl.co"` |  |
-| istio.ingressGateway.name | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.gateways[0] | string | `"istio-gateways/gateway"` |  |
+| istio.ingress.host | string | `"genus.example.com"` |  |
+| istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
 | istio.retries | object | `{}` |  |

--- a/charts/genus/templates/virtualService.yaml
+++ b/charts/genus/templates/virtualService.yaml
@@ -8,12 +8,39 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   gateways:
-    - {{ .Values.istio.ingressGateway.name | quote }}
-  hosts:
-  {{- range .Values.istio.ingressGateway.hosts }}
+  {{- range .Values.istio.ingress.gateways }}
     - {{ . | quote }}
   {{- end }}
+  hosts:
+    - {{ .Values.istio.ingress.host | quote }}
+  {{- range .Values.istio.ingress.redirectHosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
+  # Redirect routes
+  {{- range .Values.istio.virtualServiceRoutes.http }}
+    - match:
+      {{- range $.Values.istio.ingress.redirectHosts }}
+      - uri:
+          exact: {{ . | quote }}
+      {{- end }}
+      redirect:
+        authority: {{ $.Values.istio.ingress.host | quote }}
+      {{- with $.Values.istio.corsPolicy }}
+      corsPolicy:
+      {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- if $.Values.istio.retries }}
+      retries:
+      {{ toYaml $.Values.istio.retries | nindent 8 }}
+      timeout: {{ required "You must specify an overall timeout to use retries" $.Values.istio.overallTimeout}}
+      {{- else if $.Values.istio.overallTimeout }}
+      timeout: {{ $.Values.istio.overallTimeout }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  # Normal routes
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       - port: {{ .port }}
@@ -26,8 +53,10 @@ spec:
           host: {{ (print $.Values.service "." $.Release.Namespace ".svc.cluster.local")  | quote }}
           port:
             number: {{ .targetPort }}
+      {{- with $.Values.istio.corsPolicy }}
       corsPolicy:
-      {{- toYaml $.Values.istio.corsPolicy | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $.Values.istio.retries }}
       retries:
       {{ toYaml $.Values.istio.retries | nindent 8 }}
@@ -36,6 +65,7 @@ spec:
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
   {{- end }}
+  {{- if .Values.istio.virtualServiceRoutes.tcp }}
   tcp:
   {{- range .Values.istio.virtualServiceRoutes.tcp }}
     - match:
@@ -52,5 +82,6 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/genus/values.yaml
+++ b/charts/genus/values.yaml
@@ -68,10 +68,11 @@ istio:
     {}
     # networking.istio.io/exportTo: .
 
-  ingressGateway:
-    name: istio-gateways/gateway
-    hosts:
-      - genus.testnet.topl.co
+  ingress:
+    gateways: 
+    - istio-gateways/gateway
+    host: genus.example.com
+    redirectHosts: []
 
   corsPolicy:
     allowOrigins:


### PR DESCRIPTION
## Purpose
Related to: https://github.com/Topl/helm-charts/pull/43

I wanted to take a different approach and use a more SEO friendly 301 redirect for our http routes. Instead of having multiple hosts point to the same instance, we now have multiple hosts that route to 1 host, which maps to the pod. (for http traffic).

For `tcp`, we can't use 301 redirects, so just use the old behavior of multiple hosts -> 1 pod.

## Approach
* Update `ingressGateway` block to just be `ingress`.
* Support passing list for `gateways` (replaces `ingressGateway.name`.
* Revert back to just using 1 `host` instead of list.
* Add `redirectHosts` list to specify other hosts that are redirected to the `host`.

## Testing
* Deployed to https://dev.explore.topl.co
* Ensured this URL redirects to https://dev.explore.apparatus.live with a 301 redirect.

Checklist:

* [ ] I have bumped the chart version for chart changes.
* [ ] I have validated the chart with `helm template --debug ./charts/<chart>`.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`.

Changes are automatically published when merged to `main`. They are not published on branches.
