### PR TITLE
Use authority to match instead of URI

### DIFF
--- a/charts/annulus/Chart.yaml
+++ b/charts/annulus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "v1.4.2"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.13
+version: 0.1.14
 
 name: annulus
 description: A Helm chart for Annulus, an Apparatus blockchain explorer.

--- a/charts/annulus/README.md
+++ b/charts/annulus/README.md
@@ -1,6 +1,6 @@
 # annulus
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![AppVersion: v1.4.2](https://img.shields.io/badge/AppVersion-v1.4.2-informational?style=flat-square)
+![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![AppVersion: v1.4.2](https://img.shields.io/badge/AppVersion-v1.4.2-informational?style=flat-square)
 
 A Helm chart for Annulus, an Apparatus blockchain explorer.
 

--- a/charts/annulus/templates/virtualService.yaml
+++ b/charts/annulus/templates/virtualService.yaml
@@ -22,7 +22,7 @@ spec:
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
-      - uri:
+      - authority:
           exact: {{ . | quote }}
       {{- end }}
       redirect:

--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "2.0.0-beta3"
 kubeVersion: ">=1.23.0-0"
-version: 0.2.5
+version: 0.2.6
 
 name: bifrost
 description: A Helm chart for Bifrost, the Apparatus blockchain node built for good.

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -1,6 +1,6 @@
 # bifrost
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
 
 A Helm chart for Bifrost, the Apparatus blockchain node built for good.
 

--- a/charts/bifrost/templates/virtualService.yaml
+++ b/charts/bifrost/templates/virtualService.yaml
@@ -22,7 +22,7 @@ spec:
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
-      - uri:
+      - authority:
           exact: {{ . | quote }}
       {{- end }}
       redirect:

--- a/charts/bitcoin-node/Chart.yaml
+++ b/charts/bitcoin-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "23"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.3
+version: 0.1.4
 
 name: bitcoin-node
 description: A Helm chart for running a Bitcoin node.

--- a/charts/bitcoin-node/README.md
+++ b/charts/bitcoin-node/README.md
@@ -1,6 +1,6 @@
 # bitcoin-node
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 23](https://img.shields.io/badge/AppVersion-23-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 23](https://img.shields.io/badge/AppVersion-23-informational?style=flat-square)
 
 A Helm chart for running a Bitcoin node.
 

--- a/charts/bitcoin-node/templates/virtualService.yaml
+++ b/charts/bitcoin-node/templates/virtualService.yaml
@@ -22,7 +22,7 @@ spec:
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
-      - uri:
+      - authority:
           exact: {{ . | quote }}
       {{- end }}
       redirect:

--- a/charts/btc-bridge/Chart.yaml
+++ b/charts/btc-bridge/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "latest"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.4
+version: 0.1.5
 
 name: btc-bridge
 description: Helm Chart for deploying the Apparatus BTC Bridge.

--- a/charts/btc-bridge/README.md
+++ b/charts/btc-bridge/README.md
@@ -1,6 +1,6 @@
 # btc-bridge
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Helm Chart for deploying the Apparatus BTC Bridge.
 

--- a/charts/btc-bridge/templates/virtualService.yaml
+++ b/charts/btc-bridge/templates/virtualService.yaml
@@ -22,7 +22,7 @@ spec:
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
-      - uri:
+      - authority:
           exact: {{ . | quote }}
       {{- end }}
       redirect:

--- a/charts/btc-wallet/Chart.yaml
+++ b/charts/btc-wallet/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "latest"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.4
+version: 0.1.5
 
 name: btc-wallet
 description: Helm Chart for deploying the Apparatus BTC Wallet.

--- a/charts/btc-wallet/README.md
+++ b/charts/btc-wallet/README.md
@@ -1,6 +1,6 @@
 # btc-wallet
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Helm Chart for deploying the Apparatus BTC Wallet.
 

--- a/charts/btc-wallet/templates/virtualService.yaml
+++ b/charts/btc-wallet/templates/virtualService.yaml
@@ -22,7 +22,7 @@ spec:
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
-      - uri:
+      - authority:
           exact: {{ . | quote }}
       {{- end }}
       redirect:

--- a/charts/faucet/Chart.yaml
+++ b/charts/faucet/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "0.1.0"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.6
+version: 0.1.7
 
 name: faucet
 description: Helm Chart for deploying the Apparatus Faucet.

--- a/charts/faucet/README.md
+++ b/charts/faucet/README.md
@@ -1,6 +1,6 @@
 # faucet
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Helm Chart for deploying the Apparatus Faucet.
 

--- a/charts/faucet/templates/virtualService.yaml
+++ b/charts/faucet/templates/virtualService.yaml
@@ -22,7 +22,7 @@ spec:
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
-      - uri:
+      - authority:
           exact: {{ . | quote }}
       {{- end }}
       redirect:

--- a/charts/genus/Chart.yaml
+++ b/charts/genus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "2.0.0-beta3"
 kubeVersion: ">=1.23.0-0"
-version: 0.2.9
+version: 0.2.10
 
 name: genus
 description: Helm Chart for Genus, the data indexer for Apparatus.

--- a/charts/genus/README.md
+++ b/charts/genus/README.md
@@ -1,6 +1,6 @@
 # genus
 
-![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
+![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
 
 Helm Chart for Genus, the data indexer for Apparatus.
 

--- a/charts/genus/templates/virtualService.yaml
+++ b/charts/genus/templates/virtualService.yaml
@@ -22,7 +22,7 @@ spec:
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
-      - uri:
+      - authority:
           exact: {{ . | quote }}
       {{- end }}
       redirect:


### PR DESCRIPTION
## Purpose
Quick update, to use `authority` instead of `uri` for the match redirect.
https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest

This will allow us to match the base part of the URL more consistently.

## Approach
* Use `authority` instead of `uri` for `VirtualService` match.

## Testing
Tested the following:
* https://dev.explore.topl.co redirects to: https://dev.explore.apparatus.live
* dev.explore.topl.co redirects to https://dev.explore.apparatus.live
* https://dev.explore.topl.co/#/chain/toplnet/block_details/6NNNTXFBotis7uMawQkMc65wEzCoP2hDEYHUyqSKi5RY redirects to: https://dev.explore.apparatus.live/#/chain/toplnet/block_details/6NNNTXFBotis7uMawQkMc65wEzCoP2hDEYHUyqSKi5RY

Checklist:

* [x] I have bumped the chart version for chart changes.
* [x] I have validated the chart with `helm template --debug ./charts/<chart>`.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`.

Changes are automatically published when merged to `main`. They are not published on branches.
