### PR TITLE
[BN-1277]: Implement Local Envoy Rate Limting

### DIFF
--- a/charts/annulus/Chart.yaml
+++ b/charts/annulus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "v1.4.2"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.14
+version: 0.1.15
 
 name: annulus
 description: A Helm chart for Annulus, an Apparatus blockchain explorer.

--- a/charts/annulus/README.md
+++ b/charts/annulus/README.md
@@ -1,6 +1,6 @@
 # annulus
 
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![AppVersion: v1.4.2](https://img.shields.io/badge/AppVersion-v1.4.2-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![AppVersion: v1.4.2](https://img.shields.io/badge/AppVersion-v1.4.2-informational?style=flat-square)
 
 A Helm chart for Annulus, an Apparatus blockchain explorer.
 
@@ -41,6 +41,10 @@ Kubernetes: `>=1.23.0-0`
 | istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
+| istio.rateLimiting.http.enabled | bool | `false` |  |
+| istio.rateLimiting.http.fill_interval | string | `"60s"` |  |
+| istio.rateLimiting.http.max_tokens | int | `5000` |  |
+| istio.rateLimiting.http.tokens_per_fill | int | `5000` |  |
 | istio.retries | object | `{}` |  |
 | istio.virtualServiceRoutes.http[0].matchPrefix | list | `[]` |  |
 | istio.virtualServiceRoutes.http[0].port | int | `443` |  |

--- a/charts/annulus/templates/envoyFilter.yaml
+++ b/charts/annulus/templates/envoyFilter.yaml
@@ -1,33 +1,16 @@
-{{- if or (and .Values.istio.enabled .Values.istio.createGrpcWebFilter) (and .Values.istio.enabled .Values.istio.rateLimiting.rpc.enabled) }}
+{{- if or  .Values.istio.enabled .Values.istio.rateLimiting.http.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: {{ .Values.service | lower | quote }}
   labels:
-    {{- include "genus.labels" . | nindent 4 }}
+    {{- include "annulus.labels" . | nindent 4 }}
 spec:
   workloadSelector:
     labels:
       app: {{ .Values.service | lower | quote }}
   configPatches:
-    {{- if .Values.istio.createGrpcWebFilter }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-              subFilter:
-                name: "envoy.filters.http.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: "envoy.grpc_web"
-          typed_config:
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb"
-    {{- end }}
-    {{- if .Values.istio.rateLimiting.rpc.enabled }}
+    {{- if .Values.istio.rateLimiting.http.enabled }}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_INBOUND
@@ -62,9 +45,9 @@ spec:
               value:
                 stat_prefix: http_local_rate_limiter
                 token_bucket:
-                  max_tokens: {{ .Values.istio.rateLimiting.rpc.max_tokens }}
-                  tokens_per_fill: {{ .Values.istio.rateLimiting.rpc.tokens_per_fill }}
-                  fill_interval: {{ .Values.istio.rateLimiting.rpc.fill_interval }}
+                  max_tokens: {{ .Values.istio.rateLimiting.http.max_tokens }}
+                  tokens_per_fill: {{ .Values.istio.rateLimiting.http.tokens_per_fill }}
+                  fill_interval: {{ .Values.istio.rateLimiting.http.fill_interval }}
                 filter_enabled:
                   runtime_key: local_rate_limit_enabled
                   default_value:
@@ -80,28 +63,5 @@ spec:
                     header:
                       key: x-local-rate-limit
                       value: 'true'
-    {{- end }}
-    {{- if .Values.istio.rateLimiting.p2p.enabled }}
-    - applyTo: NETWORK_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        listener:
-          portNumber: 9085
-          filterChain:
-            filter:
-              name: "envoy.filters.network.tcp_proxy"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: envoy.filters.network.local_ratelimit
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.local_ratelimit.v3.LocalRateLimit
-            value:
-              stat_prefix: tcp_local_rate_limiter
-              token_bucket:
-                max_tokens: {{ .Values.istio.rateLimiting.p2p.max_tokens }}
-                tokens_per_fill: {{ .Values.istio.rateLimiting.p2p.tokens_per_fill }}
-                fill_interval: {{ .Values.istio.rateLimiting.p2p.fill_interval }}
     {{- end }}
 {{- end }}

--- a/charts/annulus/values.yaml
+++ b/charts/annulus/values.yaml
@@ -64,6 +64,13 @@ istio:
     host: annulus.example.com
     # Adds 301 redirects for the provided hosts to the main host.
     redirectHosts: []
+  
+  rateLimiting:
+    http:
+      enabled: false
+      max_tokens: 5000
+      tokens_per_fill: 5000
+      fill_interval: 60s
 
   # # The overall timeout for requests to this service
   # # Optional

--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "2.0.0-beta3"
 kubeVersion: ">=1.23.0-0"
-version: 0.2.6
+version: 0.2.7
 
 name: bifrost
 description: A Helm chart for Bifrost, the Apparatus blockchain node built for good.

--- a/charts/bifrost/README.md
+++ b/charts/bifrost/README.md
@@ -1,6 +1,6 @@
 # bifrost
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
 
 A Helm chart for Bifrost, the Apparatus blockchain node built for good.
 
@@ -68,6 +68,14 @@ Kubernetes: `>=1.23.0-0`
 | istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
+| istio.rateLimiting.p2p.enabled | bool | `false` |  |
+| istio.rateLimiting.p2p.fill_interval | string | `"60s"` |  |
+| istio.rateLimiting.p2p.max_tokens | int | `5000` |  |
+| istio.rateLimiting.p2p.tokens_per_fill | int | `5000` |  |
+| istio.rateLimiting.rpc.enabled | bool | `false` |  |
+| istio.rateLimiting.rpc.fill_interval | string | `"60s"` |  |
+| istio.rateLimiting.rpc.max_tokens | int | `5000` |  |
+| istio.rateLimiting.rpc.tokens_per_fill | int | `5000` |  |
 | istio.retries | object | `{}` |  |
 | istio.virtualServiceRoutes.http[0].matchPrefix | list | `[]` |  |
 | istio.virtualServiceRoutes.http[0].port | int | `443` |  |

--- a/charts/bifrost/templates/envoyFilter.yaml
+++ b/charts/bifrost/templates/envoyFilter.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.istio.enabled) (.Values.istio.createGrpcWebFilter) }}
+{{- if or (and .Values.istio.enabled .Values.istio.createGrpcWebFilter) (and .Values.istio.enabled .Values.istio.rateLimiting.rpc.enabled) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -10,6 +10,7 @@ spec:
     labels:
       app: {{ .Values.service | lower | quote }}
   configPatches:
+    {{- if .Values.istio.createGrpcWebFilter }}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_INBOUND
@@ -25,4 +26,82 @@ spec:
           name: "envoy.grpc_web"
           typed_config:
             "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb"
+    {{- end }}
+    {{- if .Values.istio.rateLimiting.rpc.enabled }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: http_local_rate_limiter
+    - applyTo: HTTP_ROUTE
+      match:
+        context: SIDECAR_INBOUND
+        routeConfiguration:
+          vhost:
+            name: "inbound|http|9084"
+            route:
+              action: ANY
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.local_ratelimit:
+              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+              type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              value:
+                stat_prefix: http_local_rate_limiter
+                token_bucket:
+                  max_tokens: {{ .Values.istio.rateLimiting.rpc.max_tokens }}
+                  tokens_per_fill: {{ .Values.istio.rateLimiting.rpc.tokens_per_fill }}
+                  fill_interval: {{ .Values.istio.rateLimiting.rpc.fill_interval }}
+                filter_enabled:
+                  runtime_key: local_rate_limit_enabled
+                  default_value:
+                    numerator: 100
+                    denominator: HUNDRED
+                filter_enforced:
+                  runtime_key: local_rate_limit_enforced
+                  default_value:
+                    numerator: 100
+                    denominator: HUNDRED
+                response_headers_to_add:
+                  - append: false
+                    header:
+                      key: x-local-rate-limit
+                      value: 'true'
+    {{- end }}
+    {{- if .Values.istio.rateLimiting.p2p.enabled }}
+    - applyTo: NETWORK_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          portNumber: 9085
+          filterChain:
+            filter:
+              name: "envoy.filters.network.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.network.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.network.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: tcp_local_rate_limiter
+              token_bucket:
+                max_tokens: {{ .Values.istio.rateLimiting.p2p.max_tokens }}
+                tokens_per_fill: {{ .Values.istio.rateLimiting.p2p.tokens_per_fill }}
+                fill_interval: {{ .Values.istio.rateLimiting.p2p.fill_interval }}
+    {{- end }}
 {{- end }}

--- a/charts/bifrost/templates/virtualService.yaml
+++ b/charts/bifrost/templates/virtualService.yaml
@@ -19,6 +19,7 @@ spec:
   {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
   # Redirect routes
+  {{- if .Values.istio.ingress.redirectHosts}}
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
@@ -38,6 +39,7 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
   # Normal routes

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -94,6 +94,18 @@ istio:
     - istio-gateways/gateway
     host: bifrost.example.com
     redirectHosts: []
+  
+  rateLimiting:
+    p2p:
+      enabled: false
+      max_tokens: 5000
+      tokens_per_fill: 5000
+      fill_interval: 60s
+    rpc:
+      enabled: false
+      max_tokens: 5000
+      tokens_per_fill: 5000
+      fill_interval: 60s
 
   corsPolicy:
     allowOrigins:

--- a/charts/btc-bridge/Chart.yaml
+++ b/charts/btc-bridge/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "latest"
 kubeVersion: ">=1.23.0-0"
-version: 0.1.6
+version: 0.1.7
 
 name: btc-bridge
 description: Helm Chart for deploying the Apparatus BTC Bridge.

--- a/charts/btc-bridge/README.md
+++ b/charts/btc-bridge/README.md
@@ -1,6 +1,6 @@
 # btc-bridge
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Helm Chart for deploying the Apparatus BTC Bridge.
 
@@ -60,6 +60,10 @@ Kubernetes: `>=1.23.0-0`
 | backend.istio.ingress.redirectHosts | list | `[]` |  |
 | backend.istio.outlierDetection | object | `{}` |  |
 | backend.istio.overallTimeout | string | `nil` |  |
+| backend.istio.rateLimiting.tcp.enabled | bool | `true` |  |
+| backend.istio.rateLimiting.tcp.fill_interval | string | `"60s"` |  |
+| backend.istio.rateLimiting.tcp.max_tokens | int | `5000` |  |
+| backend.istio.rateLimiting.tcp.tokens_per_fill | int | `5000` |  |
 | backend.istio.retries | object | `{}` |  |
 | backend.istio.virtualServiceRoutes.http[0].matchPrefix | list | `[]` |  |
 | backend.istio.virtualServiceRoutes.http[0].port | int | `443` |  |
@@ -120,6 +124,10 @@ Kubernetes: `>=1.23.0-0`
 | ui.istio.ingress.redirectHosts | list | `[]` |  |
 | ui.istio.outlierDetection | object | `{}` |  |
 | ui.istio.overallTimeout | string | `nil` |  |
+| ui.istio.rateLimiting.http.enabled | bool | `false` |  |
+| ui.istio.rateLimiting.http.fill_interval | string | `"60s"` |  |
+| ui.istio.rateLimiting.http.max_tokens | int | `5000` |  |
+| ui.istio.rateLimiting.http.tokens_per_fill | int | `5000` |  |
 | ui.istio.retries | object | `{}` |  |
 | ui.istio.virtualServiceRoutes.http[0].matchPrefix | list | `[]` |  |
 | ui.istio.virtualServiceRoutes.http[0].port | int | `443` |  |

--- a/charts/btc-bridge/templates/backend/envoyFilter.yaml
+++ b/charts/btc-bridge/templates/backend/envoyFilter.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.backend.istio.enabled .Values.backend.istio.rateLimiting.tcp.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ .Values.service | lower | quote }}
+  labels:
+    {{- include "btc-bridge.labels" . | nindent 4 }}
+spec:
+  workloadSelector:
+    labels:
+      app: {{ .Values.service | lower | quote }}
+  configPatches:
+    {{- if .Values.backend.istio.rateLimiting.tcp.enabled }}
+    - applyTo: NETWORK_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          portNumber: 9085
+          filterChain:
+            filter:
+              name: "envoy.filters.network.tcp_proxy"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.network.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.network.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: tcp_local_rate_limiter
+              token_bucket:
+                max_tokens: {{ .Values.backend.istio.rateLimiting.tcp.max_tokens }}
+                tokens_per_fill: {{ .Values.backend.istio.rateLimiting.tcp.tokens_per_fill }}
+                fill_interval: {{ .Values.backend.istio.rateLimiting.tcp.fill_interval }}
+    {{- end }}
+{{- end }}

--- a/charts/btc-bridge/templates/ui/envoyFilter.yaml
+++ b/charts/btc-bridge/templates/ui/envoyFilter.yaml
@@ -1,33 +1,16 @@
-{{- if or (and .Values.istio.enabled .Values.istio.createGrpcWebFilter) (and .Values.istio.enabled .Values.istio.rateLimiting.rpc.enabled) }}
+{{- if and .Values.ui.istio.enabled .Values.ui.istio.rateLimiting.http.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: {{ .Values.service | lower | quote }}
   labels:
-    {{- include "genus.labels" . | nindent 4 }}
+    {{- include "btc-bridge.ui.labels" . | nindent 4 }}
 spec:
   workloadSelector:
     labels:
       app: {{ .Values.service | lower | quote }}
   configPatches:
-    {{- if .Values.istio.createGrpcWebFilter }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.filters.network.http_connection_manager"
-              subFilter:
-                name: "envoy.filters.http.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: "envoy.grpc_web"
-          typed_config:
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb"
-    {{- end }}
-    {{- if .Values.istio.rateLimiting.rpc.enabled }}
+    {{- if .Values.ui.istio.rateLimiting.http.enabled }}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_INBOUND
@@ -62,9 +45,9 @@ spec:
               value:
                 stat_prefix: http_local_rate_limiter
                 token_bucket:
-                  max_tokens: {{ .Values.istio.rateLimiting.rpc.max_tokens }}
-                  tokens_per_fill: {{ .Values.istio.rateLimiting.rpc.tokens_per_fill }}
-                  fill_interval: {{ .Values.istio.rateLimiting.rpc.fill_interval }}
+                  max_tokens: {{ .Values.ui.istio.rateLimiting.http.max_tokens }}
+                  tokens_per_fill: {{ .Values.ui.istio.rateLimiting.http.tokens_per_fill }}
+                  fill_interval: {{ .Values.ui.istio.rateLimiting.http.fill_interval }}
                 filter_enabled:
                   runtime_key: local_rate_limit_enabled
                   default_value:
@@ -80,28 +63,5 @@ spec:
                     header:
                       key: x-local-rate-limit
                       value: 'true'
-    {{- end }}
-    {{- if .Values.istio.rateLimiting.p2p.enabled }}
-    - applyTo: NETWORK_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        listener:
-          portNumber: 9085
-          filterChain:
-            filter:
-              name: "envoy.filters.network.tcp_proxy"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: envoy.filters.network.local_ratelimit
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.network.local_ratelimit.v3.LocalRateLimit
-            value:
-              stat_prefix: tcp_local_rate_limiter
-              token_bucket:
-                max_tokens: {{ .Values.istio.rateLimiting.p2p.max_tokens }}
-                tokens_per_fill: {{ .Values.istio.rateLimiting.p2p.tokens_per_fill }}
-                fill_interval: {{ .Values.istio.rateLimiting.p2p.fill_interval }}
     {{- end }}
 {{- end }}

--- a/charts/btc-bridge/values.yaml
+++ b/charts/btc-bridge/values.yaml
@@ -76,6 +76,13 @@ ui:
       # Adds 301 redirects for the provided hosts to the main host.
       redirectHosts: []
 
+    rateLimiting:
+      http:
+        enabled: false
+        max_tokens: 5000
+        tokens_per_fill: 5000
+        fill_interval: 60s
+
     # # The overall timeout for requests to this service
     # # Optional
     overallTimeout: # 24h
@@ -229,6 +236,13 @@ backend:
       redirectHosts: []
       matchPrefix:
         - "/"
+
+    rateLimiting:
+      tcp:
+        enabled: true
+        max_tokens: 5000
+        tokens_per_fill: 5000
+        fill_interval: 60s
 
     virtualServiceRoutes:
       http:

--- a/charts/genus/Chart.yaml
+++ b/charts/genus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: "2.0.0-beta3"
 kubeVersion: ">=1.23.0-0"
-version: 0.2.10
+version: 0.2.11
 
 name: genus
 description: Helm Chart for Genus, the data indexer for Apparatus.

--- a/charts/genus/README.md
+++ b/charts/genus/README.md
@@ -1,6 +1,6 @@
 # genus
 
-![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
+![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![AppVersion: 2.0.0-beta3](https://img.shields.io/badge/AppVersion-2.0.0--beta3-informational?style=flat-square)
 
 Helm Chart for Genus, the data indexer for Apparatus.
 
@@ -60,6 +60,14 @@ Kubernetes: `>=1.23.0-0`
 | istio.ingress.redirectHosts | list | `[]` |  |
 | istio.outlierDetection | object | `{}` |  |
 | istio.overallTimeout | string | `nil` |  |
+| istio.rateLimiting.p2p.enabled | bool | `false` |  |
+| istio.rateLimiting.p2p.fill_interval | string | `"60s"` |  |
+| istio.rateLimiting.p2p.max_tokens | int | `5000` |  |
+| istio.rateLimiting.p2p.tokens_per_fill | int | `5000` |  |
+| istio.rateLimiting.rpc.enabled | bool | `false` |  |
+| istio.rateLimiting.rpc.fill_interval | string | `"60s"` |  |
+| istio.rateLimiting.rpc.max_tokens | int | `5000` |  |
+| istio.rateLimiting.rpc.tokens_per_fill | int | `5000` |  |
 | istio.retries | object | `{}` |  |
 | istio.virtualServiceRoutes.http[0].matchPrefix | list | `[]` |  |
 | istio.virtualServiceRoutes.http[0].port | int | `443` |  |

--- a/charts/genus/templates/virtualService.yaml
+++ b/charts/genus/templates/virtualService.yaml
@@ -19,6 +19,7 @@ spec:
   {{- if .Values.istio.virtualServiceRoutes.http }}
   http:
   # Redirect routes
+  {{- if .Values.istio.ingress.redirectHosts}}
   {{- range .Values.istio.virtualServiceRoutes.http }}
     - match:
       {{- range $.Values.istio.ingress.redirectHosts }}
@@ -38,6 +39,7 @@ spec:
       {{- else if $.Values.istio.overallTimeout }}
       timeout: {{ $.Values.istio.overallTimeout }}
       {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
   # Normal routes

--- a/charts/genus/values.yaml
+++ b/charts/genus/values.yaml
@@ -74,6 +74,18 @@ istio:
     host: genus.example.com
     redirectHosts: []
 
+  rateLimiting:
+    p2p:
+      enabled: false
+      max_tokens: 5000
+      tokens_per_fill: 5000
+      fill_interval: 60s
+    rpc:
+      enabled: false
+      max_tokens: 5000
+      tokens_per_fill: 5000
+      fill_interval: 60s
+
   corsPolicy:
     allowOrigins:
       - regex: ".*"


### PR DESCRIPTION
## Purpose
To prevent scaling attacks against our services, implement a configurable rate limit at the Envoy Proxy level.

This will allow us to configure how much traffic each individual workload will be able to handle.

https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/local_rate_limiting

## Approach
* Implement http and tcp rate limiting for our main services.

## Testing
* Deployed to GKE.
* Validated that rate limiting worked at local level.

Checklist:

* [x] I have bumped the chart version for chart changes.
* [x] I have validated the chart with `helm template --debug ./charts/<chart>`.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I updated the `README.md` via `docker run --rm --volume "$(pwd)/charts:/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`.

Changes are automatically published when merged to `main`. They are not published on branches.
